### PR TITLE
Explicitely allow lslhhtp connections in the Outbound URL filter to support script derived messages.

### DIFF
--- a/OpenSim/Framework/OutboundUrlFilter.cs
+++ b/OpenSim/Framework/OutboundUrlFilter.cs
@@ -239,7 +239,13 @@ namespace OpenSim.Framework
                     {
 //                        m_log.DebugFormat("[OUTBOUND URL FILTER]: Found [{0}] in blacklist for {1}", url, Name);
 
-                        // Check blacklist exceptions
+                        // if the endpoint is destined to an LSL script, always allow.
+                        if (url.indexOf("/lslhttp/") != -1)
+                        {
+                            return true;
+                        }
+
+                        // Check blacklist exceptions for non-LSL exceptions
                         allowed
                             = OutboundUrlFilter.IsInNetwork(
                                 addr, url.Port, m_blacklistExceptionNetworks, m_blacklistExceptionEndPoints, Name);


### PR DESCRIPTION
Issue 82 - LSL endpoints must not be filtered.