### PR TITLE
CoreJ2K 2.1.0 improvements. yolo.

### DIFF
--- a/OpenSim/Capabilities/Handlers/GetTexture/GetTextureHandler.cs
+++ b/OpenSim/Capabilities/Handlers/GetTexture/GetTextureHandler.cs
@@ -169,13 +169,13 @@ namespace OpenSim.Capabilities.Handlers
                         return true;
                     }
                 }
-           }
-           else // it was on the cache
-           {
-               //m_log.DebugFormat("[GETTEXTURE]: texture was in the cache");
-               WriteTextureData(request, response, texture, format);
-               return true;
-           }
+            }
+            else // it was on the cache
+            {
+                //m_log.DebugFormat("[GETTEXTURE]: texture was in the cache");
+                WriteTextureData(request, response, texture, format);
+                return true;
+            }
 
             //response = new Hashtable();
 
@@ -300,8 +300,7 @@ namespace OpenSim.Capabilities.Handlers
                 {
                     // Try CoreJ2K first
                     var j2k = J2kImage.FromBytes(texture.Data);
-                    if (j2k != null)
-                        skImage = j2k.As<SKImage>();
+                    skImage = j2k?.As<SKImage>();
                 }
                 catch
                 {

--- a/OpenSim/Capabilities/Handlers/GetTexture/GetTextureRobustHandler.cs
+++ b/OpenSim/Capabilities/Handlers/GetTexture/GetTextureRobustHandler.cs
@@ -314,7 +314,7 @@ namespace OpenSim.Capabilities.Handlers
         {
             m_log.DebugFormat("[GETTEXTURE]: Converting texture {0} to {1}", texture.ID, format);
             byte[] data = Array.Empty<byte>();
-            // Try CSJ2K (CoreJ2K) first to get an SKImage
+            // Try CoreJ2K first to get an SKImage
             try
             {
                 SKImage skImage = null;
@@ -322,12 +322,11 @@ namespace OpenSim.Capabilities.Handlers
                 try
                 {
                     var j2k = J2kImage.FromBytes(texture.Data);
-                    if (j2k != null)
-                        skImage = j2k.As<SKImage>();
+                    skImage = j2k?.As<SKImage>();
                 }
                 catch (Exception)
                 {
-                    // CSJ2K not available or failed, fall back to OpenJPEG
+                    // CoreJ2K not available or failed, fall back to OpenJPEG
                     skImage = null;
                 }
 

--- a/OpenSim/Capabilities/Handlers/OpenSim.Capabilities.Handlers.csproj
+++ b/OpenSim/Capabilities/Handlers/OpenSim.Capabilities.Handlers.csproj
@@ -27,6 +27,6 @@
     <PackageReference Include="log4net" Version="3.2.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.10" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
-    <PackageReference Include="CoreJ2K.Skia" Version="1.2.2.68" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.1.0.101" />
   </ItemGroup>
 </Project>

--- a/OpenSim/Framework/OpenSim.Framework.csproj
+++ b/OpenSim/Framework/OpenSim.Framework.csproj
@@ -161,7 +161,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
-    <PackageReference Include="CoreJ2K.Skia" Version="1.2.2.68" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.1.0.101" />
     <PackageReference Include="log4net" Version="3.2.0" />
     <PackageReference Include="Mono.Addins" Version="1.4.1" />
     <PackageReference Include="Mono.Addins.Setup" Version="1.4.1" />

--- a/OpenSim/Region/CoreModules/Agent/TextureSender/J2KDecoderModule.cs
+++ b/OpenSim/Region/CoreModules/Agent/TextureSender/J2KDecoderModule.cs
@@ -225,7 +225,7 @@ namespace OpenSim.Region.CoreModules.Agent.TextureSender
 //                "[J2KDecoderModule]: Doing J2K decoding of {0} bytes for asset {1}", j2kData.Length, assetID);
 
             bool decodedSuccessfully = true;
-            components = 0; // Not used by CoreJ2K decode path
+            components = 0;
 
             if (!TryLoadCacheForAsset(assetID, out layers))
             {
@@ -237,7 +237,7 @@ namespace OpenSim.Region.CoreModules.Agent.TextureSender
                     {
                         // Extract layer information from CoreJ2K - create default layers for now
                         layers = CreateDefaultLayers(j2kData.Length);
-                        components = 3; // Typical JPEG2000 has 3 components (RGB)
+                        components = j2k.NumberOfComponents;
                         decodedSuccessfully = true;
                         // Cache decoded layers
                         SaveFileCacheForAsset(assetID, layers);

--- a/OpenSim/Region/CoreModules/OpenSim.Region.CoreModules.csproj
+++ b/OpenSim/Region/CoreModules/OpenSim.Region.CoreModules.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="Mono.Addins.CecilReflector" Version="1.4.1" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.10" />
-    <PackageReference Include="CoreJ2K.Skia" Version="1.2.2.68" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.1.0.101" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 </Project>

--- a/OpenSim/Region/Framework/OpenSim.Region.Framework.csproj
+++ b/OpenSim/Region/Framework/OpenSim.Region.Framework.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
-    <PackageReference Include="CoreJ2K.Skia" Version="1.2.2.68" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.1.0.101" />
     <PackageReference Include="log4net" Version="3.2.0" />
     <PackageReference Include="Mono.Addins" Version="1.4.1" />
     <PackageReference Include="Mono.Addins.CecilReflector" Version="1.4.1" />

--- a/OpenSim/Region/PhysicsModules/Meshing/Meshmerizer/Meshmerizer.cs
+++ b/OpenSim/Region/PhysicsModules/Meshing/Meshmerizer/Meshmerizer.cs
@@ -25,10 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.IO;
 using OpenSim.Framework;
 using OpenSim.Region.Framework.Scenes;
 using OpenSim.Region.Framework.Interfaces;
@@ -37,6 +34,7 @@ using OpenMetaverse;
 using OpenMetaverse.StructuredData;
 using SkiaSharp;
 using CoreJ2K;
+using CoreJ2K.Configuration;
 using System.IO.Compression;
 using PrimMesher;
 using log4net;
@@ -70,6 +68,9 @@ namespace OpenSim.Region.PhysicsModule.Meshing
 
         // Mesh cache. Static so it can be shared across instances of this class
         private static Dictionary<ulong, Mesh> m_uniqueMeshes = new Dictionary<ulong, Mesh>();
+
+        private readonly J2KDecoderConfiguration decoderConfig = new J2KDecoderConfiguration()
+            .WithHighestResolution();
 
         #region INonSharedRegionModule
         public string Name
@@ -661,9 +662,8 @@ namespace OpenSim.Region.PhysicsModule.Meshing
                     SKImage skImage = null;
                     try
                     {
-                        var j2k = J2kImage.FromBytes(primShape.SculptData);
-                        if (j2k != null)
-                            skImage = j2k.As<SKImage>();
+                        var j2k = J2kImage.FromBytes(primShape.SculptData, decoderConfig);
+                        skImage = j2k?.As<SKImage>();
                     }
                     catch
                     {

--- a/OpenSim/Region/PhysicsModules/Meshing/OpenSim.Region.PhysicsModule.Meshing.csproj
+++ b/OpenSim/Region/PhysicsModules/Meshing/OpenSim.Region.PhysicsModule.Meshing.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Mono.Addins" Version="1.4.1" />
     <PackageReference Include="Mono.Addins.CecilReflector" Version="1.4.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.10" />
-    <PackageReference Include="CoreJ2K.Skia" Version="1.2.2.68" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.1.0.101" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
   <ItemGroup>

--- a/OpenSim/Region/PhysicsModules/ubOdeMeshing/Meshmerizer.cs
+++ b/OpenSim/Region/PhysicsModules/ubOdeMeshing/Meshmerizer.cs
@@ -26,24 +26,22 @@
  */
 //#define SPAM
 
-using OpenSim.Framework;
-using OpenSim.Region.Framework.Scenes;
-using OpenSim.Region.Framework.Interfaces;
-using OpenSim.Region.PhysicsModules.SharedBase;
-using OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet;
-
+using CoreJ2K;
+using CoreJ2K.Configuration;
+using log4net;
+using Mono.Addins;
+using Nini.Config;
 using OpenMetaverse;
 using OpenMetaverse.StructuredData;
-
-using SkiaSharp;
-using CoreJ2K;
-using System.IO.Compression;
+using OpenSim.Framework;
+using OpenSim.Region.Framework.Interfaces;
+using OpenSim.Region.Framework.Scenes;
+using OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet;
+using OpenSim.Region.PhysicsModules.SharedBase;
 using PrimMesher;
-using log4net;
-using Nini.Config;
+using SkiaSharp;
+using System.IO.Compression;
 using System.Reflection;
-
-using Mono.Addins;
 
 namespace OpenSim.Region.PhysicsModule.ubODEMeshing
 {
@@ -56,7 +54,7 @@ namespace OpenSim.Region.PhysicsModule.ubODEMeshing
         // raw files can be imported by blender so a visual inspection of the results can be done
 
         const float floatPI = MathF.PI;
-        private readonly static string cacheControlFilename = "cntr";
+        private static readonly string cacheControlFilename = "cntr";
         private bool m_Enabled = false;
 
         public static object diskLock = new();
@@ -75,6 +73,9 @@ namespace OpenSim.Region.PhysicsModule.ubODEMeshing
 
         private readonly Dictionary<AMeshKey, Mesh> m_uniqueMeshes = new();
         private readonly Dictionary<AMeshKey, Mesh> m_uniqueReleasedMeshes = new();
+
+        private readonly J2KDecoderConfiguration decoderConfig = new J2KDecoderConfiguration()
+            .WithHighestResolution();
 
         #region INonSharedRegionModule
         public string Name
@@ -715,7 +716,7 @@ namespace OpenSim.Region.PhysicsModule.ubODEMeshing
                 SKBitmap skBitmap = null;
                 try
                 {
-                    var j2k = J2kImage.FromBytes(primShape.SculptData);
+                    var j2k = J2kImage.FromBytes(primShape.SculptData, decoderConfig);
                     if (j2k != null)
                         skBitmap = j2k.As<SKBitmap>();
                 }

--- a/OpenSim/Region/PhysicsModules/ubOdeMeshing/OpenSim.Region.PhysicsModule.ubOdeMeshing.csproj
+++ b/OpenSim/Region/PhysicsModules/ubOdeMeshing/OpenSim.Region.PhysicsModule.ubOdeMeshing.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Mono.Addins" Version="1.4.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.10" />
     <PackageReference Include="Mono.Addins.CecilReflector" Version="1.4.1" />
-    <PackageReference Include="CoreJ2K.Skia" Version="1.2.2.68" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.1.0.101" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
   <ItemGroup>

--- a/OpenSim/Services/Connectors/OpenSim.Services.Connectors.csproj
+++ b/OpenSim/Services/Connectors/OpenSim.Services.Connectors.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
-    <PackageReference Include="CoreJ2K.Skia" Version="1.2.2.68" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.1.0.101" />
     <PackageReference Include="log4net" Version="3.2.0" />
     <PackageReference Include="Mono.Addins" Version="1.4.1" />
     <PackageReference Include="Mono.Addins.CecilReflector" Version="1.4.1" />

--- a/OpenSim/Services/MapImageService/OpenSim.Services.MapImageService.csproj
+++ b/OpenSim/Services/MapImageService/OpenSim.Services.MapImageService.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
-    <PackageReference Include="CoreJ2K.Skia" Version="1.2.2.68" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.1.0.101" />
     <ProjectReference Include="..\..\Framework\OpenSim.Framework.csproj" />
     <ProjectReference Include="..\..\Framework\Console\OpenSim.Framework.Console.csproj" />
     <ProjectReference Include="..\..\Framework\Servers\HttpServer\OpenSim.Framework.Servers.HttpServer.csproj" />


### PR DESCRIPTION
VectorRender and MapImageModule generate j2k. Tweakering j2k decoding. 

CoreJ2K 2.1.0 is fully ISO-15554-1 compliant and 3x faster with a much smaller memory footprint. 

Fixed a hack in `DoJ2KDecode()` that assumed three component images.

I didn't test this.