### PR TITLE
Fix blocked experience handling in llRequestExperiencePermissions

### DIFF
--- a/Source/OpenSim.Region.ScriptEngine.Shared/Api/LSL_Api.cs
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/Api/LSL_Api.cs
@@ -18557,7 +18557,7 @@ namespace OpenSim.Region.ScriptEngine.Shared.Api
                                             new DetectParams[0]));
                     return;
                 }
-                else if (experiencePermission == ExperiencePermission.Allowed)
+                else if (experiencePermission == ExperiencePermission.Blocked)
                 {
                     m_ScriptEngine.PostScriptEvent(m_item.ItemID, new EventParams(
                             "experience_permissions_denied", new Object[] {


### PR DESCRIPTION
## Summary
- Fix incorrect enum check in `llRequestExperiencePermissions` where `ExperiencePermission.Allowed` was checked twice.
- Route `ExperiencePermission.Blocked` to `experience_permissions_denied` with `XP_ERROR_NOT_PERMITTED`.
- Prevent blocked users from falling through to the permission prompt flow.