### PR TITLE
Temporary fixup for BulletSim and ubODE loading

### DIFF
--- a/Source/OpenSim.Server.RegionServer/AppData/OpenSim.Region.PhysicsModules.BulletS.dll.config
+++ b/Source/OpenSim.Server.RegionServer/AppData/OpenSim.Region.PhysicsModules.BulletS.dll.config
@@ -1,0 +1,7 @@
+<configuration>
+  <dllmap os="windows" cpu="x86-64" dll="BulletSim" target="runtimes/win-x64/native/BulletSim.dll" />
+  <dllmap os="osx" cpu="x86-64" dll="BulletSim" target="runtimes/osx-x64/native/libBulletSim.dylib" />
+  <dllmap os="osx" cpu="arm64" dll="BulletSim" target="runtimes/osx-arm64/native/libBulletSim.dylib" />
+  <dllmap os="!windows,osx" cpu="x86-64" dll="BulletSim" target="runtimes/linux-x64/native/libBulletSim.so" />
+  <dllmap os="!windows,osx" cpu="arm64" dll="BulletSim" target="runtimes/linux-arm64/native/libBulletSim.so" />
+</configuration>

--- a/Source/OpenSim.Server.RegionServer/AppData/OpenSim.Region.PhysicsModules.ubODE.dll.config
+++ b/Source/OpenSim.Server.RegionServer/AppData/OpenSim.Region.PhysicsModules.ubODE.dll.config
@@ -1,0 +1,7 @@
+<configuration>
+  <dllmap os="windows" cpu="x86-64" dll="ubode" target="runtimes/win-x64/native/ubode.dll" />
+  <dllmap os="osx" cpu="arm64" dll="ubode" target="runtimes/osx-arm64/native/libubode.dylib" />
+  <dllmap os="osx" cpu="x86-64" dll="ubode" target="runtimes/osx-x64/native/libubode.dylib" />
+  <dllmap os="!windows,osx" cpu="x86-64" dll="ubode" target="runtimes/linux-x64/native/libubode.so" />
+  <dllmap os="!windows,osx" cpu="arm64" dll="ubode" target="runtimes/linux-arm64/native/libubode.so" />
+</configuration>


### PR DESCRIPTION
#164  

The native libaries were not loading correctly for these modules.

Adding the config files is a temporary fix so that the import resolver in the OpenMetaverse hack can run.

