### PR TITLE
Add mesh name assignment to prim if available in inner_instance_list

### DIFF
--- a/OpenSim/Region/ClientStack/Linden/Caps/BunchOfCaps/BunchOfCaps.cs
+++ b/OpenSim/Region/ClientStack/Linden/Caps/BunchOfCaps/BunchOfCaps.cs
@@ -950,7 +950,9 @@ namespace OpenSim.Region.ClientStack.Linden
                         prim.RezzerID = creatorID;
                         prim.CreationDate = Util.UnixTimeSinceEpoch();
 
-                        if (grp == null)
+                        if (inner_instance_list.ContainsKey("mesh_name") && !string.IsNullOrEmpty(inner_instance_list["mesh_name"].AsString()))
+                            prim.Name = inner_instance_list["mesh_name"].AsString();
+                        else if (grp == null)
                             prim.Name = assetName;
                         else
                             prim.Name = assetName + "#" + i.ToString();


### PR DESCRIPTION
This brings Avastar mesh uploads closer to Second Life behavior by allowing individual mesh parts to retain their intended names instead of always being assigned generated off of the root mesh name.