### PR TITLE
Fix: send updated appearance back to self after outfit change

### DIFF
--- a/OpenSim/Region/CoreModules/Avatar/AvatarFactory/AvatarFactoryModule.cs
+++ b/OpenSim/Region/CoreModules/Avatar/AvatarFactory/AvatarFactoryModule.cs
@@ -227,7 +227,14 @@ namespace OpenSim.Region.CoreModules.Avatar.AvatarFactory
 
         private void SendAppearance(ScenePresence sp)
         {
-            // Send the appearance to everyone in the scene
+            // Send the updated appearance back to the avatar themselves so that
+            // mLastProcessedAppearance on the viewer is kept current.  Without
+            // this, resetSkeleton() on the viewer replays the stale appearance
+            // from region-entry and reverts the avatar's textures to a previous
+            // outfit.
+            sp.SendAppearanceToAgentNF(sp);
+
+            // Send the appearance to everyone else in the scene
             sp.SendAppearanceToAllOtherAgents();
 
             // Send animations back to the avatar as well


### PR DESCRIPTION
This addresses the issue with Firestorm "Reset Skeleton"

When a user changes outfit, the server was broadcasting the new AvatarAppearance to all other nearby clients but not back to the avatar themselves. The viewer keeps a cached copy (mLastProcessedAppearance) of the last AvatarAppearance it received from the server, which was only set at region entry and never updated on subsequent outfit changes.

Firestorm resetSkeleton() replays mLastProcessedAppearance to rebuild the avatar, so it was reverting textures to whatever outfit was worn at region entry.

Fix: call SendAppearanceToAgentNF(sp) on self inside SendAppearance() so that mLastProcessedAppearance stays current after every outfit change, matching the existing behaviour already present at region entry.