### PR TITLE
Fix for Region Server loading

### DIFF
--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Land/LandServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Land/LandServiceInConnectorModule.cs
@@ -98,7 +98,7 @@ public class LandServiceInConnectorModule : ISharedRegionModule, ILandService
         if (!m_Registered)
         {
             m_Registered = true;
-            Object[] args = new Object[] { m_Config, MainServer.Instance, this, scene };
+            Object[] args = new Object[] { m_Config, MainServer.Instance.DefaultServer, this, scene };
             ServerUtils.LoadPlugin<IServiceConnector>("OpenSim.Server.Handlers.dll:LandServiceInConnector", args);
         }
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Neighbour/NeighbourServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Neighbour/NeighbourServiceInConnectorModule.cs
@@ -97,7 +97,7 @@ public class NeighbourServiceInConnectorModule : ISharedRegionModule, INeighbour
         if (!m_Registered)
         {
             m_Registered = true;
-            Object[] args = new Object[] { m_Config, MainServer.Instance, this, scene };
+            Object[] args = new Object[] { m_Config, MainServer.Instance.DefaultServer, this, scene };
             ServerUtils.LoadPlugin<IServiceConnector>("OpenSim.Server.Handlers.dll:NeighbourServiceInConnector", args);
         }
 

--- a/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Simulation/SimulationServiceInConnectorModule.cs
+++ b/Source/OpenSim.Region.CoreModules/ServiceConnectorsIn/Simulation/SimulationServiceInConnectorModule.cs
@@ -104,7 +104,7 @@ public class SimulationServiceInConnectorModule : ISharedRegionModule
 
             m_log.Info("[SIM SERVICE]: Starting...");
 
-            Object[] args = new Object[] { m_Config, MainServer.Instance, scene };
+            Object[] args = new Object[] { m_Config, MainServer.Instance.DefaultServer, scene };
 
             ServerUtils.LoadPlugin<IServiceConnector>("OpenSim.Server.Handlers.dll:SimulationServiceInConnector", args);
         }


### PR DESCRIPTION
Three local services were not loading via ServerUtils.LoadPlugin due to a type mismatch on the constructor args.

Fix for issue #177 

