### PR TITLE
Bf/binaryformatter removal

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">

--- a/Source/OpenSim.Region.CoreModules/Asset/FlotsamAssetCache.cs
+++ b/Source/OpenSim.Region.CoreModules/Asset/FlotsamAssetCache.cs
@@ -26,7 +26,7 @@
  */
 
 using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Xml.Serialization;
 using System.Text;
 using System.Timers;
 using log4net;
@@ -59,6 +59,11 @@ public class FlotsamAssetCache : ISharedRegionModule, IAssetCache, IAssetService
 
     private const string m_ModuleName = "FlotsamAssetCache";
     private string m_CacheDirectory = "assetcache";
+
+    // Fixed-type serializer for the on-disk asset cache. Replaces BinaryFormatter;
+    // resolves no types from the byte stream. XmlSerializer is thread-safe for
+    // Serialize/Deserialize so a single shared instance is fine.
+    private static readonly XmlSerializer m_assetSerializer = new XmlSerializer(typeof(AssetBase));
     private string m_assetLoader;
     private string m_assetLoaderArgs;
 
@@ -153,6 +158,12 @@ public class FlotsamAssetCache : ISharedRegionModule, IAssetCache, IAssetService
                     m_FileCacheEnabled = assetConfig.GetBoolean("FileCacheEnabled", m_FileCacheEnabled);
                     m_CacheDirectory = assetConfig.GetString("CacheDirectory", m_CacheDirectory);
                     m_CacheDirectory = Path.GetFullPath(m_CacheDirectory);
+
+                    // Use a format-versioned subdirectory so legacy BinaryFormatter
+                    // cache files written by older builds are never read by the new
+                    // XML reader. Old files stay in the parent dir (harmless) and can
+                    // be deleted manually; the cache simply regenerates here.
+                    m_CacheDirectory = Path.Combine(m_CacheDirectory, "format2");
 
                     m_MemoryCacheEnabled = assetConfig.GetBoolean("MemoryCacheEnabled", m_MemoryCacheEnabled);
                     m_MemoryExpiration = assetConfig.GetDouble("MemoryCacheTimeout", m_MemoryExpiration);
@@ -519,8 +530,10 @@ public class FlotsamAssetCache : ISharedRegionModule, IAssetCache, IAssetService
             if (stream.Length == 0) // Empty file will trigger exception below
                 return null;
 
-            BinaryFormatter bformatter = new();
-            asset = (AssetBase)bformatter.Deserialize(stream);
+            // Only the fixed-type XML format is read. A legacy BinaryFormatter
+            // file (or any corrupt file) fails to parse and is handled below as
+            // a cache miss; the byte stream is never BinaryFormatter-deserialized.
+            asset = (AssetBase)m_assetSerializer.Deserialize(stream);
 
             m_DiskHits++;
         }
@@ -1005,8 +1018,7 @@ public class FlotsamAssetCache : ISharedRegionModule, IAssetCache, IAssetService
 
                 using (Stream stream = File.Open(tempname, FileMode.Create))
                 {
-                    BinaryFormatter bformatter = new();
-                    bformatter.Serialize(stream, asset);
+                    m_assetSerializer.Serialize(stream, asset);
                     stream.Flush();
                 }
                 m_lastFileAccessTimeChange?.Add(filename, 900000);

--- a/Source/OpenSim.Region.Framework/Scenes/KeyframeMotion.cs
+++ b/Source/OpenSim.Region.Framework/Scenes/KeyframeMotion.cs
@@ -28,7 +28,6 @@
 using System.Timers;
 using OpenMetaverse;
 using OpenSim.Framework;
-using System.Runtime.Serialization.Formatters.Binary;
 using Timer = System.Timers.Timer;
 
 namespace OpenSim.Region.Framework.Scenes;
@@ -300,10 +299,56 @@ public class KeyframeMotion
 
         try
         {
-            using (MemoryStream ms = new MemoryStream(data))
+            // ONLY the explicit KFM1 format is accepted. Legacy BinaryFormatter
+            // blobs (and any malformed / short / oversized input) are refused by
+            // returning null - callers treat that as "no keyframe motion", which
+            // is the intended graceful degradation. We never BinaryFormatter-
+            // deserialize this (possibly foreign) byte[].
+            if (data == null || data.Length < 8 || data.Length > KFM_MAX_BYTES)
+                return null;
+
+            using (MemoryStream ms = new MemoryStream(data, false))
+            using (BinaryReader br = new BinaryReader(ms))
             {
-                BinaryFormatter fmt = new BinaryFormatter();
-                newMotion = (KeyframeMotion)fmt.Deserialize(ms);
+                if (br.ReadByte() != (byte)'K' || br.ReadByte() != (byte)'F' ||
+                    br.ReadByte() != (byte)'M' || br.ReadByte() != (byte)'1')
+                    return null;
+                if (br.ReadUInt32() != KFM_VERSION)
+                    return null;
+
+                newMotion = new KeyframeMotion();
+
+                newMotion.m_serializedPosition = ReadVector3(br);
+                newMotion.m_basePosition = ReadVector3(br);
+                newMotion.m_baseRotation = ReadQuaternion(br);
+                newMotion.m_currentFrame = ReadKeyframe(br);
+
+                int frameCount = br.ReadInt32();
+                if (frameCount < 0 || frameCount > KFM_MAX_FRAMES)
+                    return null;
+                List<Keyframe> frames = new List<Keyframe>(frameCount);
+                for (int i = 0; i < frameCount; i++)
+                    frames.Add(ReadKeyframe(br));
+                newMotion.m_frames = frames;
+
+                int kfCount = br.ReadInt32();
+                if (kfCount < -1 || kfCount > KFM_MAX_FRAMES)
+                    return null;
+                if (kfCount < 0)
+                    newMotion.m_keyframes = null;
+                else
+                {
+                    Keyframe[] kfs = new Keyframe[kfCount];
+                    for (int i = 0; i < kfCount; i++)
+                        kfs[i] = ReadKeyframe(br);
+                    newMotion.m_keyframes = kfs;
+                }
+
+                newMotion.m_mode = (PlayMode)br.ReadInt32();
+                newMotion.m_data = (DataFormat)br.ReadInt32();
+                newMotion.m_running = br.ReadBoolean();
+                newMotion.m_iterations = br.ReadInt32();
+                newMotion.m_skipLoops = br.ReadInt32();
             }
 
             newMotion.m_group = grp;
@@ -364,6 +409,23 @@ public class KeyframeMotion
 
         if (m_running)
             Start();
+    }
+
+    // ---- KFM1 safe serialization format ----
+    // Explicit length-prefixed binary, replaces the old BinaryFormatter blob.
+    // Magic 'K''F''M''1' + uint version, then the serializable fields written
+    // by hand. No type names in the stream; nothing arbitrary is instantiated.
+    private const uint KFM_VERSION = 1;
+    private const int  KFM_MAX_FRAMES = 1 << 20;          // sanity bound on counts
+    private const int  KFM_MAX_BYTES  = 16 * 1024 * 1024; // sanity bound on blob size
+
+    // Parameterless ctor used only by FromData() to build an instance we then
+    // populate field-by-field from a KFM1 blob.
+    private KeyframeMotion()
+    {
+        m_timerStopped = true;
+        m_isCrossing = false;
+        m_waitingCrossing = false;
     }
 
     public KeyframeMotion(SceneObjectGroup grp, PlayMode mode, DataFormat data)
@@ -824,16 +886,120 @@ public class KeyframeMotion
 
         using (MemoryStream ms = new MemoryStream())
         {
-            BinaryFormatter fmt = new BinaryFormatter();
             if (!m_selected && tmp != null)
                 m_serializedPosition = tmp.AbsolutePosition;
-            fmt.Serialize(ms, this);
+
+            // Write the explicit KFM1 format (no BinaryFormatter). bw wraps ms;
+            // we do not dispose bw so ms stays open for ToArray() below (ms is
+            // disposed by its own using).
+            BinaryWriter bw = new BinaryWriter(ms);
+            bw.Write((byte)'K');
+            bw.Write((byte)'F');
+            bw.Write((byte)'M');
+            bw.Write((byte)'1');
+            bw.Write(KFM_VERSION);
+
+            WriteVector3(bw, m_serializedPosition);
+            WriteVector3(bw, m_basePosition);
+            WriteQuaternion(bw, m_baseRotation);
+            WriteKeyframe(bw, m_currentFrame);
+
+            List<Keyframe> frames = m_frames;
+            bw.Write(frames == null ? 0 : frames.Count);
+            if (frames != null)
+            {
+                for (int i = 0; i < frames.Count; i++)
+                    WriteKeyframe(bw, frames[i]);
+            }
+
+            if (m_keyframes == null)
+                bw.Write(-1);
+            else
+            {
+                bw.Write(m_keyframes.Length);
+                for (int i = 0; i < m_keyframes.Length; i++)
+                    WriteKeyframe(bw, m_keyframes[i]);
+            }
+
+            bw.Write((int)m_mode);
+            bw.Write((int)m_data);
+            bw.Write(m_running);
+            bw.Write(m_iterations);
+            bw.Write(m_skipLoops);
+            bw.Flush();
+
             m_group = tmp;
             if (!timerWasStopped && m_running && !m_waitingCrossing)
                 StartTimer();
 
             return ms.ToArray();
         }
+    }
+
+    // ---- KFM1 primitive (de)serialization helpers ----
+
+    private static void WriteVector3(BinaryWriter bw, Vector3 v)
+    {
+        bw.Write(v.X);
+        bw.Write(v.Y);
+        bw.Write(v.Z);
+    }
+
+    private static Vector3 ReadVector3(BinaryReader br)
+    {
+        float x = br.ReadSingle();
+        float y = br.ReadSingle();
+        float z = br.ReadSingle();
+        return new Vector3(x, y, z);
+    }
+
+    private static void WriteQuaternion(BinaryWriter bw, Quaternion q)
+    {
+        bw.Write(q.X);
+        bw.Write(q.Y);
+        bw.Write(q.Z);
+        bw.Write(q.W);
+    }
+
+    private static Quaternion ReadQuaternion(BinaryReader br)
+    {
+        float x = br.ReadSingle();
+        float y = br.ReadSingle();
+        float z = br.ReadSingle();
+        float w = br.ReadSingle();
+        return new Quaternion(x, y, z, w);
+    }
+
+    private static void WriteKeyframe(BinaryWriter bw, Keyframe kf)
+    {
+        bw.Write(kf.Position.HasValue);
+        if (kf.Position.HasValue)
+            WriteVector3(bw, kf.Position.Value);
+
+        bw.Write(kf.Rotation.HasValue);
+        if (kf.Rotation.HasValue)
+            WriteQuaternion(bw, kf.Rotation.Value);
+
+        WriteQuaternion(bw, kf.StartRotation);
+        bw.Write(kf.TimeMS);
+        bw.Write(kf.TimeTotal);
+        WriteVector3(bw, kf.AngularVelocity);
+        WriteVector3(bw, kf.StartPosition);
+    }
+
+    private static Keyframe ReadKeyframe(BinaryReader br)
+    {
+        Keyframe kf = new Keyframe();
+        if (br.ReadBoolean())
+            kf.Position = ReadVector3(br);
+        if (br.ReadBoolean())
+            kf.Rotation = ReadQuaternion(br);
+        kf.StartRotation = ReadQuaternion(br);
+        kf.TimeMS = br.ReadInt32();
+        kf.TimeTotal = br.ReadInt32();
+        kf.AngularVelocity = ReadVector3(br);
+        kf.StartPosition = ReadVector3(br);
+        return kf;
     }
 
     public void StartCrossingCheck()

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstAbstract.cs
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstAbstract.cs
@@ -1471,8 +1471,10 @@ public abstract class XMRInstAbstract: ScriptBaseClass
         DELEGATE,
         SDTCLOBJ,
         SYSCHAR,
-        SYSERIAL,
-        THROWNEX
+        SYSERIAL,   // legacy BinaryFormatter blob - REFUSED on read (never deserialized)
+        THROWNEX,   // legacy BinaryFormatter blob - REFUSED on read (never deserialized)
+        THROWNEX2,  // safe ScriptThrownException: only the (separately-sent) thrown value
+        SYSUNSUP    // marker for a system type we refuse to serialize without BinaryFormatter
     }
 
     /**
@@ -1703,26 +1705,24 @@ public abstract class XMRInstAbstract: ScriptBaseClass
         }
         else if(graph is ScriptThrownException ScriptThrownExceptiongraph)
         {
-            MemoryStream memoryStream = new MemoryStream();
-            System.Runtime.Serialization.Formatters.Binary.BinaryFormatter bformatter =
-                    new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
-            bformatter.Serialize(memoryStream, graph);
-            byte[] rawBytes = memoryStream.ToArray();
-            mow.Write((byte)Ser.THROWNEX);
-            mow.Write((int)rawBytes.Length);
-            mow.Write(rawBytes);
+            // No BinaryFormatter. The only field that matters is the thrown LSL
+            // value, which is sent explicitly (and recursively) right after the
+            // opcode. The base Exception message/stack is not used by scripts
+            // (xmrExceptionThrownValue() returns 'thrown'), so it is dropped.
+            mow.Write((byte)Ser.THROWNEX2);
             SendObjValue(ScriptThrownExceptiongraph.thrown);
         }
         else
         {
-            MemoryStream memoryStream = new MemoryStream();
-            System.Runtime.Serialization.Formatters.Binary.BinaryFormatter bformatter =
-                    new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
-            bformatter.Serialize(memoryStream, graph);
-            byte[] rawBytes = memoryStream.ToArray();
-            mow.Write((byte)Ser.SYSERIAL);
-            mow.Write(rawBytes.Length);
-            mow.Write(rawBytes);
+            // No BinaryFormatter. Every system type the VM can normally hold
+            // (bool/char/int/float/double/string plus all LSL/XMR types) is
+            // already handled by an explicit opcode above. Anything reaching
+            // here is an unsupported type: emit a refusal marker so the SAVE
+            // still succeeds, but on restore the value cannot be reconstructed
+            // and the script restarts clean rather than us ever deserializing
+            // arbitrary bytes. Reference idents stay consistent because the
+            // object was already registered in migrateOutObjects above.
+            mow.Write((byte)Ser.SYSUNSUP);
         }
     }
 
@@ -1806,7 +1806,11 @@ public abstract class XMRInstAbstract: ScriptBaseClass
             return typeof(LSL_Vector);
         if(str == "xa")
             return typeof(XMR_Array);
-        return Type.GetType(str, true);
+        // No arbitrary type resolution from the migration stream. Only the
+        // fixed short-code types above are permitted; anything else aborts the
+        // restore (caught by LoadScriptState -> script restarts clean) instead
+        // of resolving an attacker-named type via Type.GetType.
+        throw new Exception("YEngine migration: refusing to resolve unlisted type code '" + str + "'");
     }
 
     /**
@@ -1980,28 +1984,25 @@ public abstract class XMRInstAbstract: ScriptBaseClass
                 return clobj;
 
             case Ser.SYSERIAL:
-            {
-                int rawLength = mir.ReadInt32();
-                byte[] rawBytes = mir.ReadBytes(rawLength);
-                MemoryStream memoryStream = new MemoryStream(rawBytes);
-                System.Runtime.Serialization.Formatters.Binary.BinaryFormatter bformatter =
-                        new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
-                object graph = bformatter.Deserialize(memoryStream);
-                this.migrateInObjects.Add(ident, graph);
-                return graph;
-            }
-
             case Ser.THROWNEX:
+            case Ser.SYSUNSUP:
+                // Legacy BinaryFormatter opcodes (SYSERIAL/THROWNEX) and the
+                // unsupported-type marker (SYSUNSUP) are never deserialized.
+                // Aborting here is caught by LoadScriptState, which resets the
+                // script to its default state and posts state_entry - i.e. the
+                // script restarts clean rather than us deserializing arbitrary,
+                // possibly foreign, bytes. This is the whole point of the change.
+                throw new Exception("YEngine migration: refusing legacy/unsupported BinaryFormatter value (script will restart clean)");
+
+            case Ser.THROWNEX2:
             {
-                int rawLength = mir.ReadInt32();
-                byte[] rawBytes = mir.ReadBytes(rawLength);
-                MemoryStream memoryStream = new MemoryStream(rawBytes);
-                System.Runtime.Serialization.Formatters.Binary.BinaryFormatter bformatter =
-                        new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
-                object graph = bformatter.Deserialize(memoryStream);
-                this.migrateInObjects.Add(ident, graph);
-                ((ScriptThrownException)graph).thrown = RecvObjValue();
-                return graph;
+                // Reconstruct the exception wrapper, register it BEFORE reading
+                // the thrown value so reference idents match the writer, then
+                // fill in the (separately-encoded) thrown LSL value.
+                ScriptThrownException ste = (ScriptThrownException)ScriptThrownException.Wrap(0);
+                this.migrateInObjects.Add(ident, ste);
+                ste.thrown = RecvObjValue();
+                return ste;
             }
 
             default:

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstCtor.cs
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/XMRInstCtor.cs
@@ -1127,6 +1127,21 @@ public partial class XMRInstance
         return ReadXTypedValue(tag);
     }
 
+    // Allow-list of value types permitted when importing legacy XEngine-format
+    // script state from XML. The 'type' attribute in that XML is attacker-
+    // influenceable (it rides in on foreign objects / archives), so we must
+    // never resolve and instantiate an arbitrary named type. Only these known
+    // LSL / primitive value types are accepted; anything else degrades to null
+    // (the variable takes its default) rather than an arbitrary CreateInstance.
+    private static bool IsAllowedXStateType(Type t)
+    {
+        return t == typeof(int)    || t == typeof(double) || t == typeof(string) ||
+               t == typeof(bool)   || t == typeof(float)  || t == typeof(long)   ||
+               t == typeof(LSL_Integer) || t == typeof(LSL_Float)    ||
+               t == typeof(LSL_String)  || t == typeof(LSL_List)     ||
+               t == typeof(LSL_Vector)  || t == typeof(LSL_Rotation);
+    }
+
     private static object ReadXTypedValue(XmlNode tag)
     {
         Object varValue;
@@ -1151,7 +1166,7 @@ public partial class XMRInstance
 
             assembly = itemType + ", OpenSim.Region.ScriptEngine.Shared";
             itemT = Type.GetType(assembly);
-            if (itemT == null)
+            if (itemT == null || !IsAllowedXStateType(itemT))
                 return null;
 
             varValue = Activator.CreateInstance(itemT, args);
@@ -1161,6 +1176,8 @@ public partial class XMRInstance
         }
         else
         {
+            if (!IsAllowedXStateType(itemT))
+                return null;
             varValue = Convert.ChangeType(tag.InnerText, itemT);
         }
         return varValue;
@@ -1292,12 +1309,15 @@ private LinkedList<EventParams> RestoreEventQueue(XmlNode eventsN)
 
             string assembly = itemType + ", OpenSim.Region.ScriptEngine.Shared";
             itemT = Type.GetType(assembly);
-            if(itemT == null)
+            if(itemT == null || !IsAllowedXStateType(itemT))
             {
                 return null;
             }
             return Activator.CreateInstance(itemT, args);
         }
+
+        if(!IsAllowedXStateType(itemT))
+            return null;
 
         return Convert.ChangeType(item.InnerText, itemT);
     }

--- a/Source/OpenSim.Server.GridServer/runtimeconfig.template.json
+++ b/Source/OpenSim.Server.GridServer/runtimeconfig.template.json
@@ -3,7 +3,6 @@
       "System.GC.Server": false,
       "System.GC.HighMemoryPercent": 50,
       "System.Globalization.UseNls": true,
-      "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
-      "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": true
+      "System.Reflection.Metadata.MetadataUpdater.IsSupported": false
   }
 }

--- a/Source/OpenSim.Server.RegionServer/runtimeconfig.template.json
+++ b/Source/OpenSim.Server.RegionServer/runtimeconfig.template.json
@@ -4,7 +4,6 @@
       "System.GC.HighMemoryPercent": 50,
       "System.Globalization.UseNls": true,
       "System.Reflection.Metadata.MetadataUpdater.IsSupported": false,
-      "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": true,
       "System.Runtime.TieredCompilation.QuickJit": false
   }
 }


### PR DESCRIPTION
Removes the last live BinaryFormatter code paths from the tree. Ported from
Legion Grid.

BinaryFormatter resolves types from the byte stream, which makes any
attacker-influenced blob a code-execution vector. It's disabled by default on
.NET 8 — hence the `EnableUnsafeBinaryFormatterSerialization` opt-in currently
in `Directory.Build.props` — and removed outright in .NET 9. Three call sites
remained; this converts all of them and drops the opt-in.

**FlotsamAssetCache**
The on-disk asset cache now uses a fixed-type `XmlSerializer(typeof(AssetBase))`
for both read and write, so no type is ever resolved from the stream.

The cache directory gains a `format2` segment, so pre-existing cache files from
older builds are never fed to the new reader — the cache simply regenerates in
the versioned subdirectory. Unreadable or corrupt files are still handled by the
existing catch chain as a cache miss. Size-limit and cleanup-timer logic are
unchanged.

*Operator impact:* a cold cache after upgrade. Self-healing.

**YEngine script-state migration**
The `Ser.*` tagged migration stream no longer uses BinaryFormatter:
- `THROWNEX` → new `THROWNEX2` opcode encoding only the separately-sent thrown
  LSL value; no formatter, no type names in the stream.
- The catch-all `SYSERIAL` write path is replaced by a `SYSUNSUP` refusal
  marker, so saves still succeed; that value isn't restorable.
- On read, legacy `SYSERIAL`/`THROWNEX` and the `SYSUNSUP` marker abort the
  restore. That's caught by `LoadScriptState`, which resets the script and posts
  `state_entry` — foreign bytes are never deserialized.
- `String2SysType`'s `Type.GetType(str, true)` fallback is replaced by a throw;
  only the fixed short-code types resolve.
- XEngine-format XML state import is gated by an `IsAllowedXStateType`
  allow-list; unknown `type` attributes degrade to null rather than
  `Activator.CreateInstance` on an arbitrary type.

*Operator impact:* `migrationVersion` is deliberately unchanged, so ordinary
script state round-trips as before. Only states carrying a serialized exception
or catch-all system object — rare, in-flight values — abort restore, and those
scripts restart clean at `state_entry`.

**KeyframeMotion**
`Serialize()` writes an explicit length-prefixed blob: magic `KFM1`, a uint
version, then the serializable fields via `BinaryWriter`. No type names in the
stream. `FromData()` accepts only a KFM1 blob and validates magic, version, and
bounded counts/size; legacy, malformed, short or oversized input returns null,
which callers already treat as "no keyframe motion."

*Operator impact:* keyframe blobs persisted by older builds are refused on first
load after upgrade. Those in-progress animations stop and the object rests at
its persisted position; scripts can restart them, and newly saved state is KFM1
and round-trips normally. One-time cost, matching the Legion deployment.

**Flag removal**
With no live BinaryFormatter remaining, `EnableUnsafeBinaryFormatterSerialization`
is removed from `Directory.Build.props` and both server runtimeconfig templates.
Verified: no `new BinaryFormatter` or `Formatters.Binary` construction anywhere
in the tree after these changes.

(The YEngine commit body notes this removal as deferred — that was accurate at
the time it was written, before KeyframeMotion was converted. It's included here.)

**Notes for review**
- Three source files plus three build/config files. Independent of the Phlox
  work — this applies whether or not any other PR is taken.
- Each conversion refuses legacy data rather than migrating it. Deserializing it
  is the vulnerability, so refusal is the only safe option; the three failure
  modes are cache miss, graceful degradation, and clean script restart
  respectively.
- Ported from Legion Grid `slua-tier2-tables` (tag port-source-2026-07-18),
  originals ff1cb83c4b, a75104e516, 38c2531177.