### PR TITLE
Fix HGInventoryAccessModule OutboundPermission default and honor per-item Export bit

### DIFF
--- a/Source/OpenSim.Region.CoreModules/Framework/InventoryAccess/HGInventoryAccessModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Framework/InventoryAccess/HGInventoryAccessModule.cs
@@ -88,7 +88,13 @@ public class HGInventoryAccessModule : BasicInventoryAccessModule, INonSharedReg
                 IConfig thisModuleConfig = source.Configs["HGInventoryAccessModule"];
                 if (thisModuleConfig != null)
                 {
-                    m_OutboundPermission = thisModuleConfig.GetBoolean("OutboundPermission", true);
+                    // SECURITY FIX (Laxton Consulting / IMA, @llaxton, 2026-07-26): default changed from
+                    // true to false. Prior default silently allowed Hypergrid asset export from
+                    // every grid unless an administrator explicitly opted out - a default-allow
+                    // posture for content leaving the grid. This is now default-deny; grid
+                    // owners who want the prior behavior must explicitly set
+                    // OutboundPermission = true in their HGInventoryAccessModule config section.
+                    m_OutboundPermission = thisModuleConfig.GetBoolean("OutboundPermission", false);
                     m_RestrictInventoryAccessAbroad = thisModuleConfig.GetBoolean("RestrictInventoryAccessAbroad", true);
                     m_CheckSeparateAssets = thisModuleConfig.GetBoolean("CheckSeparateAssets", false);
                     m_LocalAssetsURL = thisModuleConfig.GetString("RegionHGAssetServerURI", string.Empty);
@@ -376,7 +382,15 @@ public class HGInventoryAccessModule : BasicInventoryAccessModule, INonSharedReg
         if (isForeignSender && senderAssetServer != string.Empty)
             m_assMapper.Get(item.AssetID, sender, senderAssetServer);
 
-        if (isForeignReceiver && receiverAssetServer != string.Empty && m_OutboundPermission)
+        // SECURITY FIX (Laxton Consulting / IMA, @llaxton, 2026-07-26): previously this check only
+        // consulted the grid-wide m_OutboundPermission administrative toggle and never
+        // examined the item's own CurrentPermissions Export bit - meaning a creator's
+        // explicit per-item "do not allow export" setting (PermissionMask.Export unset)
+        // was silently ignored on every Hypergrid inventory transfer. Both the grid-wide
+        // policy AND the item's own export permission must now be true for the asset to
+        // actually leave the grid.
+        bool itemExportAllowed = (item.CurrentPermissions & (uint)OpenSim.Framework.PermissionMask.Export) != 0;
+        if (isForeignReceiver && receiverAssetServer != string.Empty && m_OutboundPermission && itemExportAllowed)
             m_assMapper.Post(item.AssetID, receiver, receiverAssetServer);
     }
 


### PR DESCRIPTION
## Summary
Two related security gaps in Hypergrid asset export handling:

1. `OutboundPermission` (controls whether assets can leave this grid via Hypergrid) defaulted to `true` when unset in config. This is a default-allow posture for content export -- any grid administrator who didn't explicitly configure this setting was silently exporting assets to foreign grids by default.
2. The Hypergrid inventory-transfer code checked only the grid-wide `OutboundPermission` toggle and never examined the individual item's own `CurrentPermissions` Export bit. A content creator's explicit per-item "do not allow export" setting was silently ignored on every Hypergrid transfer, regardless of the grid-wide policy.

## Fix
1. `OutboundPermission` now defaults to `false` (deny) when not explicitly configured. Grid owners who want the prior behavior must explicitly set `OutboundPermission = true`.
2. The transfer path now also checks `(item.CurrentPermissions & (uint)PermissionMask.Export) != 0` and requires both the grid-wide policy and the item's own export permission to be true before the asset is sent to a foreign grid.

```diff
--- a/OpenSim/Region/CoreModules/Framework/InventoryAccess/HGInventoryAccessModule.cs
+++ b/OpenSim/Region/CoreModules/Framework/InventoryAccess/HGInventoryAccessModule.cs
@@ -92,7 +92,13 @@ namespace OpenSim.Region.CoreModules.Framework.InventoryAccess
                     IConfig thisModuleConfig = source.Configs["HGInventoryAccessModule"];
                     if (thisModuleConfig != null)
                     {
-                        m_OutboundPermission = thisModuleConfig.GetBoolean("OutboundPermission", true);
+                        m_OutboundPermission = thisModuleConfig.GetBoolean("OutboundPermission", false);
                         m_RestrictInventoryAccessAbroad = thisModuleConfig.GetBoolean("RestrictInventoryAccessAbroad", true);
                         m_CheckSeparateAssets = thisModuleConfig.GetBoolean("CheckSeparateAssets", false);
                         m_LocalAssetsURL = thisModuleConfig.GetString("RegionHGAssetServerURI", string.Empty);
@@ -380,7 +386,15 @@ namespace OpenSim.Region.CoreModules.Framework.InventoryAccess
             if (isForeignSender && senderAssetServer != string.Empty)
                 m_assMapper.Get(item.AssetID, sender, senderAssetServer);

-            if (isForeignReceiver && receiverAssetServer != string.Empty && m_OutboundPermission)
+            bool itemExportAllowed = (item.CurrentPermissions & (uint)OpenSim.Framework.PermissionMask.Export) != 0;
+            if (isForeignReceiver && receiverAssetServer != string.Empty && m_OutboundPermission && itemExportAllowed)
                 m_assMapper.Post(item.AssetID, receiver, receiverAssetServer);
         }
```

## Testing performed
- Confirmed against tag `tranquillity-0.9.3.9333`.
- Full solution build (`dotnet build OpenSim.sln -c Release`): 0 errors. This also caught a real ambiguous-reference bug: `PermissionMask` exists in both `OpenSim.Framework` and the external OpenMetaverse library; the fix fully qualifies to `OpenSim.Framework.PermissionMask` to resolve the ambiguity, matching the existing explicit-qualification convention already used elsewhere in the codebase (`Scene.Inventory.cs`).

## Compatibility / migration note
This is a behavioral default change. Any existing deployment relying on the previous default-allow `OutboundPermission` behavior needs to explicitly set `OutboundPermission = true` in their `[HGInventoryAccessModule]` config section after upgrading. Existing content whose creator never explicitly granted the Export permission bit will no longer transfer off-grid via Hypergrid, matching the creator's own stated intent rather than silently ignoring it.
