### PR TITLE
Fix dead DenyIdentified/DenyTransacted estate-access enforcement chain

### DIFF
--- a/Source/OpenSim.Region.ClientStack.LindenUDP/LLClientView.cs
+++ b/Source/OpenSim.Region.ClientStack.LindenUDP/LLClientView.cs
@@ -847,8 +847,18 @@ public class LLClientView : IClientAPI, IClientCore, IClientIM, IClientChat, ICl
             flags |= RegionFlags.RestrictPushObject;
         if (Scene.RegionInfo.EstateSettings.DenyAnonymous)
             flags |= RegionFlags.DenyAnonymous;
-        //DenyIdentified  unused
-        //DenyTransacted  unused
+        // SECURITY FIX (Laxton Consulting / IMA, @llaxton, 2026-07-26): these two bits were
+        // previously never computed here at all - commented out as "unused" - meaning
+        // GetRegionFlags() could never set them regardless of estate configuration.
+        // This is the root cause of the dead enforcement chain: even after fixing the
+        // capability packet construction further down in this file to read these bits
+        // correctly, the value being read was always zero because it was never set here
+        // in the first place. Follows the identical working pattern used one line above
+        // for DenyAnonymous.
+        if (Scene.RegionInfo.EstateSettings.DenyIdentified)
+            flags |= RegionFlags.DenyIdentified;
+        if (Scene.RegionInfo.EstateSettings.DenyTransacted)
+            flags |= RegionFlags.DenyTransacted;
         if (Scene.RegionInfo.RegionSettings.AllowLandJoinDivide)
             flags |= RegionFlags.AllowParcelChanges;
         //AbuseEmailToEstateOwner -> block flyover
@@ -6674,8 +6684,16 @@ public class LLClientView : IClientAPI, IClientCore, IClientIM, IClientChat, ICl
         LLSDxmlEncode2.AddElem("PassPrice", landData.PassPrice, sb);
         LLSDxmlEncode2.AddElem("PublicCount", (int)0, sb); //TODO
         LLSDxmlEncode2.AddElem("RegionDenyAnonymous", (regionFlags & (uint)RegionFlags.DenyAnonymous) != 0, sb);
-        LLSDxmlEncode2.AddElem("RegionDenyIdentified", false, sb);
-        LLSDxmlEncode2.AddElem("RegionDenyTransacted", false, sb);
+        // SECURITY FIX (Laxton Consulting / IMA, @llaxton, 2026-07-26): these two values were
+        // previously hardcoded to false regardless of actual estate configuration.
+        // EstateSettings.DenyIdentified/DenyTransacted are correctly stored and
+        // correctly folded into regionFlags by EstateManagementModule.cs, but this
+        // capability packet - which is what the viewer actually enforces client-side
+        // access restrictions against - never read those bits, silently telling every
+        // viewer these restrictions were always off. Now follows the same working
+        // pattern already used one line above for RegionDenyAnonymous.
+        LLSDxmlEncode2.AddElem("RegionDenyIdentified", (regionFlags & (uint)RegionFlags.DenyIdentified) != 0, sb);
+        LLSDxmlEncode2.AddElem("RegionDenyTransacted", (regionFlags & (uint)RegionFlags.DenyTransacted) != 0, sb);
         LLSDxmlEncode2.AddElem("RegionPushOverride", (regionFlags & (uint)RegionFlags.RestrictPushObject) != 0, sb);
         LLSDxmlEncode2.AddElem("RentPrice", (int) 0, sb);
         LLSDxmlEncode2.AddElem("RequestResult", request_result, sb);


### PR DESCRIPTION
Estate settings `DenyIdentified` and `DenyTransacted` (age/payment-verification-based access restrictions) were never actually enforced, despite being correctly stored in `EstateSettings` and correctly folded into `EstateManagementModule.cs`'s region-flags computation elsewhere in the codebase. Two separate points in the client-facing code path failed to honor them:

1. `LLClientView.cs`'s `GetRegionFlags()` never computed the `RegionFlags.DenyIdentified`/`RegionFlags.DenyTransacted` bits at all -- the lines were present only as comments (`//DenyIdentified unused`, `//DenyTransacted unused`), meaning these flags could never be set here regardless of estate configuration.
2. The `SimulatorFeatures` capability packet -- the actual mechanism viewers use to enforce these restrictions client-side -- hardcoded `RegionDenyIdentified`/`RegionDenyTransacted` to `false` unconditionally, independent of whatever `regionFlags` computed.

Because of (1), even if (2) had correctly read `regionFlags`, the value read would always have been zero. Both defects had to be fixed together to restore actual enforcement.

## Fix
`GetRegionFlags()` now computes both bits from `Scene.RegionInfo.EstateSettings`, following the identical existing pattern used one line above for `DenyAnonymous`. The capability packet now reads the computed `regionFlags` bits instead of hardcoded `false`, following the identical existing pattern used one line above for `RegionDenyAnonymous`.

```diff
--- a/OpenSim/Region/ClientStack/Linden/UDP/LLClientView.cs
+++ b/OpenSim/Region/ClientStack/Linden/UDP/LLClientView.cs
@@ -852,8 +852,18 @@ namespace OpenSim.Region.ClientStack.LindenUDP
                 flags |= RegionFlags.RestrictPushObject;
             if (Scene.RegionInfo.EstateSettings.DenyAnonymous)
                 flags |= RegionFlags.DenyAnonymous;
-            //DenyIdentified  unused
-            //DenyTransacted  unused
+            if (Scene.RegionInfo.EstateSettings.DenyIdentified)
+                flags |= RegionFlags.DenyIdentified;
+            if (Scene.RegionInfo.EstateSettings.DenyTransacted)
+                flags |= RegionFlags.DenyTransacted;
             if (Scene.RegionInfo.RegionSettings.AllowLandJoinDivide)
                 flags |= RegionFlags.AllowParcelChanges;
             //AbuseEmailToEstateOwner -> block flyover
@@ -6684,8 +6694,16 @@ namespace OpenSim.Region.ClientStack.LindenUDP
             LLSDxmlEncode2.AddElem("PassPrice", landData.PassPrice, sb);
             LLSDxmlEncode2.AddElem("PublicCount", (int)0, sb); //TODO
             LLSDxmlEncode2.AddElem("RegionDenyAnonymous", (regionFlags & (uint)RegionFlags.DenyAnonymous) != 0, sb);
-            LLSDxmlEncode2.AddElem("RegionDenyIdentified", false, sb);
-            LLSDxmlEncode2.AddElem("RegionDenyTransacted", false, sb);
+            LLSDxmlEncode2.AddElem("RegionDenyIdentified", (regionFlags & (uint)RegionFlags.DenyIdentified) != 0, sb);
+            LLSDxmlEncode2.AddElem("RegionDenyTransacted", (regionFlags & (uint)RegionFlags.DenyTransacted) != 0, sb);
             LLSDxmlEncode2.AddElem("RegionPushOverride", (regionFlags & (uint)RegionFlags.RestrictPushObject) != 0, sb);
             LLSDxmlEncode2.AddElem("RentPrice", (int) 0, sb);
             LLSDxmlEncode2.AddElem("RequestResult", request_result, sb);
```

## Testing performed
- Confirmed against tag `tranquillity-0.9.3.9333`.
- Full solution build (`dotnet build OpenSim.sln -c Release`): 0 errors.
- Traced both defects to their actual source rather than patching only the symptom -- confirmed `EstateManagementModule.cs` and `EstateSettings` already correctly store/compute these values elsewhere in the codebase; the defect was isolated to these two specific read/propagation points.

## Compatibility / migration note
This is a behavioral fix, not a new feature -- `DenyIdentified`/`DenyTransacted` are existing estate settings that estate owners may already have configured, believing them to be enforced. After this fix, any estate with these settings enabled will begin actually restricting access accordingly for the first time. Estate owners who never intended to enable these restrictions are unaffected, since the settings themselves are unchanged by this patch -- only their enforcement.
