### PR TITLE
Fix parcel-for-sale classification to check ForSale flag instead of SalePrice > 0

### DIFF
--- a/Source/OpenSim.Region.CoreModules/World/Land/LandManagementModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Land/LandManagementModule.cs
@@ -1429,7 +1429,14 @@ public class LandManagementModule : INonSharedRegionModule , ILandChannel
                 {
                     curByte = LandChannel.LAND_TYPE_OWNED_BY_GROUP;
                 }
-                else if (currentParcelLandData.SalePrice > 0 &&
+                // FIX (Laxton Consulting / IMA, @llaxton, 2026-07-29): previously checked
+                // SalePrice > 0 as a proxy for whether a parcel is for sale. Since every
+                // parcel defaults to SalePrice = 0, this made it impossible to distinguish
+                // "not for sale" from "for sale at no cost" - a genuinely free parcel with
+                // the ForSale flag actively set would never render as purchasable. Now
+                // checks the actual ForSale flag bit, matching the pattern already used
+                // correctly in this file's own purchase-validation logic.
+                else if ((currentParcelLandData.Flags & (uint)ParcelFlags.ForSale) != 0 &&
                             (currentParcelLandData.AuthBuyerID.IsZero() ||
                             currentParcelLandData.AuthBuyerID.Equals(remote_client.AgentId)))
                 {


### PR DESCRIPTION
## Summary
`LandManagementModule.cs`'s parcel-type classification method (used for map overlay and parcel-info display) determines whether a parcel should render as `LAND_TYPE_IS_FOR_SALE` using the condition `SalePrice > 0`. Since every parcel's `SalePrice` defaults to `0`, this makes it impossible to distinguish "not for sale" from "for sale at no cost" — a genuinely free (`$0`) parcel with the `ForSale` flag actively set by its owner will never be classified or rendered as purchasable, even though the actual purchase-validation path (`EventManagerOnValidateLandBuy`) already correctly checks the real `ParcelFlags.ForSale` bit and handles `$0` transactions without issue.

## Root cause
Confirmed by tracing the full parcel-purchase flow:
- `EventManagerOnValidateLandBuy` (the real purchase validator) checks `(land.LandData.Flags & (uint)(ParcelFlags.ForSale | ...)) != 0` — the correct pattern.
- The classification method at issue instead checks `currentParcelLandData.SalePrice > 0` — an incorrect proxy for "is this parcel for sale," since price and the for-sale flag are independent fields in `LandData`.

## Fix
Replace the `SalePrice > 0` condition with a direct check of the `ParcelFlags.ForSale` flag bit, matching the pattern already used correctly elsewhere in the same file's purchase-validation logic.

```diff
--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -1429,7 +1429,14 @@ namespace OpenSim.Region.CoreModules.World.Land
                     {
                         curByte = LandChannel.LAND_TYPE_OWNED_BY_GROUP;
                     }
-                    else if (currentParcelLandData.SalePrice > 0 &&
+                    // FIX (Laxton Consulting / IMA, @llaxton, 2026-07-29): previously checked
+                    // SalePrice > 0 as a proxy for whether a parcel is for sale. Since every
+                    // parcel defaults to SalePrice = 0, this made it impossible to distinguish
+                    // "not for sale" from "for sale at no cost" - a genuinely free parcel with
+                    // the ForSale flag actively set would never render as purchasable. Now
+                    // checks the actual ForSale flag bit, matching the pattern already used
+                    // correctly in this file's own purchase-validation logic.
+                    else if ((currentParcelLandData.Flags & (uint)ParcelFlags.ForSale) != 0 &&
                                 (currentParcelLandData.AuthBuyerID.IsZero() ||
                                 currentParcelLandData.AuthBuyerID.Equals(remote_client.AgentId)))
                     {
```

## Testing performed
- Confirmed against tag `tranquillity-0.9.3.9333`.
- Full solution build (`dotnet build OpenSim.sln -c Release`): 0 errors.
- Traced the complete parcel-purchase event chain (`ProcessParcelBuy` -> `TriggerValidateLandBuy`/`TriggerLandBuy` -> `EventManagerOnValidateLandBuy`/`EventManagerOnLandBuy`) to confirm this change only affects display/classification, not the actual purchase-completion logic, which was already correct.

## Compatibility
No change to purchase-transaction behavior for priced parcels. No interaction with any `IMoneyModule` implementation -- this method contains no economy-related logic at all.
