### PR TITLE
Allow free ($0) parcel purchases without requiring an active economy module

### DIFF
--- a/Source/OpenSim.Region.CoreModules/World/Land/LandManagementModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/Land/LandManagementModule.cs
@@ -1740,7 +1740,15 @@ public class LandManagementModule : INonSharedRegionModule , ILandChannel
 
     public void EventManagerOnLandBuy(Object o, EventManager.LandBuyArgs e)
     {
-        if (e.economyValidated && e.landValidated)
+        // FIX (Laxton Consulting / IMA, @llaxton, 2026-07-29): economyValidated defaults
+        // to false and is only ever set by an active IMoneyModule subscriber. With no
+        // economy module loaded at all, even a genuinely free (price 0) parcel could
+        // never complete a purchase. Now allows completion when parcelPrice == 0
+        // regardless of economyValidated; all priced-parcel (> 0) behavior, and every
+        // existing economy module, is unaffected - the validator already confirms
+        // parcelPrice matches the parcel's real stored SalePrice before landValidated
+        // can become true, so this cannot be used to buy a priced parcel for free.
+        if (e.landValidated && (e.economyValidated || e.parcelPrice == 0))
         {
             ILandObject land;
             lock (m_landList)


### PR DESCRIPTION
## Summary
`EventManagerOnLandBuy` requires `e.economyValidated == true` unconditionally to complete any land purchase. `economyValidated` defaults to `false` and is never set by core code -- it is only ever set by a subscriber to `OnValidateLandBuy`, i.e. an active `IMoneyModule` implementation. As a result, if no economy module is loaded at all, land purchases cannot complete under any circumstances, including for parcels explicitly listed for `$0`.

## Root cause
Confirmed via source trace:
- `EventManager.cs`: `public bool economyValidated = false;` -- the only place this field is initialized.
- `LandManagementModule.cs`'s `EventManagerOnLandBuy`: `if (e.economyValidated && e.landValidated)` -- only checks the flag, never sets it.
- No core code path sets `economyValidated = true` in the absence of a money-module subscriber.

## Fix
Allow purchase completion when the parcel price is exactly `0`, regardless of `economyValidated`, while leaving all priced-parcel (`parcelPrice > 0`) behavior completely unchanged -- those still require an active economy module to set `economyValidated`, exactly as today.

```diff
--- a/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
+++ b/OpenSim/Region/CoreModules/World/Land/LandManagementModule.cs
@@ -1740,7 +1747,15 @@ namespace OpenSim.Region.CoreModules.World.Land
         public void EventManagerOnLandBuy(Object o, EventManager.LandBuyArgs e)
         {
-            if (e.economyValidated && e.landValidated)
+            // FIX (Laxton Consulting / IMA, @llaxton, 2026-07-29): economyValidated defaults
+            // to false and is only ever set by an active IMoneyModule subscriber. With no
+            // economy module loaded at all, even a genuinely free (price 0) parcel could
+            // never complete a purchase. Now allows completion when parcelPrice == 0
+            // regardless of economyValidated; all priced-parcel (> 0) behavior, and every
+            // existing economy module, is unaffected - the validator already confirms
+            // parcelPrice matches the parcel's real stored SalePrice before landValidated
+            // can become true, so this cannot be used to buy a priced parcel for free.
+            if (e.landValidated && (e.economyValidated || e.parcelPrice == 0))
             {
```

## Testing performed
- Confirmed against tag `tranquillity-0.9.3.9333`, applied together with the companion fix in this same file (parcel-for-sale classification).
- Full solution build (`dotnet build OpenSim.sln -c Release`): 0 errors.
- Confirmed `landValidated` can only be `true` for a parcel whose stored `SalePrice` already matches the requested `parcelPrice` (enforced by `EventManagerOnValidateLandBuy`'s own `e.parcelPrice >= saleprice` check), so this change cannot be used to purchase a genuinely priced parcel for free.

## Compatibility
Verified this does not change behavior when an economy module is active: Gloebit's own `ValidateLandBuy` already sets `economyValidated = true` for `parcelPrice == 0` (with an explicit code comment confirming this was deliberate, existing behavior on the authors' part), so this change is additive/redundant for that specific case and only changes behavior in the previously-unsupported "no economy module loaded" configuration. No economy-module code is touched by this patch.
