### PR TITLE
Update SDK and Runtime to dotnet10, 

### DIFF
--- a/Addons/Gloebit.GloebitMoneyModule/Gloebit.GloebitMoneyModule.csproj
+++ b/Addons/Gloebit.GloebitMoneyModule/Gloebit.GloebitMoneyModule.csproj
@@ -1,9 +1,7 @@
   <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>Gloebit</AssemblyTitle>
     <Product>Gloebit</Product>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,10 +37,10 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="MySqlConnector" Version="2.5.0" />
-    <PackageReference Include="Npgsql" Version="10.0.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="MySqlConnector" Version="2.6.1" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Addons/OpenSim.Addons.Groups/OpenSim.Addons.Groups.csproj
+++ b/Addons/OpenSim.Addons.Groups/OpenSim.Addons.Groups.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Addons.Groups</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Addons.Groups</Product>
@@ -8,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Addons/OpenSim.Addons.OfflineIM/OpenSim.Addons.OfflineIM.csproj
+++ b/Addons/OpenSim.Addons.OfflineIM/OpenSim.Addons.OfflineIM.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Addons.OfflineIM</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Addons.OfflineIM</Product>
@@ -8,8 +7,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Addons/OpenSimMutelist/OpenSimMutelist.Modules.csproj
+++ b/Addons/OpenSimMutelist/OpenSimMutelist.Modules.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSimMuteList.Modules</AssemblyTitle>
     <Product>OpenSim</Product>
   </PropertyGroup>
@@ -16,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Addons/OpenSimSearch/OpenSimSearch.Modules.csproj
+++ b/Addons/OpenSimSearch/OpenSimSearch.Modules.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSimSearch.Modules</AssemblyTitle>
     <Product>OpenSim</Product>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="xmlrpc" HintPath="..\..\Library\xmlrpc.dll" />

--- a/Addons/os-webrtc-janus/Janus/WebRtcJanusService.csproj
+++ b/Addons/os-webrtc-janus/Janus/WebRtcJanusService.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>WebRtcJanusService</AssemblyTitle>
     <Version>2.1.1</Version>
   </PropertyGroup>
@@ -22,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Addons/os-webrtc-janus/WebRtcVoice/WebRtcVoice.csproj
+++ b/Addons/os-webrtc-janus/WebRtcVoice/WebRtcVoice.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <Version>2.1.1</Version>
   </PropertyGroup>
 
@@ -21,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Addons/os-webrtc-janus/WebRtcVoiceRegionModule/WebRtcVoiceRegionModule.csproj
+++ b/Addons/os-webrtc-janus/WebRtcVoiceRegionModule/WebRtcVoiceRegionModule.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <Version>2.1.1</Version>
     <AssemblyName>WebRtcVoiceRegionModule</AssemblyName>
   </PropertyGroup>
@@ -22,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Addons/os-webrtc-janus/WebRtcVoiceServiceModule/WebRtcVoiceServiceModule.csproj
+++ b/Addons/os-webrtc-janus/WebRtcVoiceServiceModule/WebRtcVoiceServiceModule.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <Version>2.1.1</Version>
   </PropertyGroup>
 
@@ -21,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,13 +1,13 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>
-      <Version>3.9.50</Version>
+      <Version>3.10.91</Version>
     </PackageReference>
     <PackageReference Include="nini-core" Version="0.9.2.16" />
     <PackageReference Include="OpenMetaverse" Version="1.0.6" />

--- a/Docs/BUILDING.md
+++ b/Docs/BUILDING.md
@@ -21,7 +21,7 @@ get or update source from git
 If no configuration is specified the default is a release build. If no platform is specified default 
 is the platform being used for the compilation.
 
-The output from the publish will be in build/<Configuration>/net8.0/<platform>/
+The output from the publish will be in build/<Configuration>/net10.0/<platform>/
 
 Where Configuration is either Debug or Release and Platform is either linux-x64 or win-x64 as shown above.
 

--- a/Docs/PLUGIN_DEVELOPMENT.md
+++ b/Docs/PLUGIN_DEVELOPMENT.md
@@ -185,7 +185,6 @@ Minimal `csproj` pattern:
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.ExampleModule</AssemblyTitle>
   </PropertyGroup>
 
@@ -195,17 +194,14 @@ Minimal `csproj` pattern:
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Nini" HintPath="../../Library/Nini.dll" />
-    <Reference Include="OpenMetaverse" HintPath="../../Library/OpenMetaverse.dll" />
-    <Reference Include="OpenMetaverseTypes" HintPath="../../Library/OpenMetaverse.Types.dll" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../../Source/OpenSim.Framework/OpenSim.Framework.csproj" />
     <ProjectReference Include="../../Source/OpenSim.Region.Framework/OpenSim.Region.Framework.csproj" />
   </ItemGroup>
 </Project>
 ```
+
+The TargetFramework and a few references common across all the projects will come from 
+Directory.Build.props
 
 ### Option B: Addons tree plugin
 
@@ -226,7 +222,6 @@ Minimal `csproj` pattern:
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Addons.ExampleModule</AssemblyTitle>
   </PropertyGroup>
 

--- a/Source/InWorldz.Phlox/InWorldz.Phlox.csproj
+++ b/Source/InWorldz.Phlox/InWorldz.Phlox.csproj
@@ -1,71 +1,39 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-    <PreserveCompilationContext>false</PreserveCompilationContext>
     <OutputType>Library</OutputType>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <ImplicitUsings>disable</ImplicitUsings>
     <AssemblyName>InWorldz.Phlox</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-    <EnableDefaultItems>false</EnableDefaultItems>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <BaseAddress>285212672</BaseAddress>
-    <ConfigurationOverrideFile></ConfigurationOverrideFile>
-    <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile></DocumentationFile>
-    <DebugSymbols>True</DebugSymbols>
-    <FileAlignment>4096</FileAlignment>
-    <Optimize>False</Optimize>
+    <PreserveCompilationContext>false</PreserveCompilationContext>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <TieredCompilationQuickJit>false</TieredCompilationQuickJit>
-    <UseCommonOutputDirectory>True</UseCommonOutputDirectory>
-    <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>False</AppendRuntimeIdentifierToOutputPath>
-    <RegisterForComInterop>False</RegisterForComInterop>
-    <RemoveIntegerChecks>False</RemoveIntegerChecks>
-    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-    <WarningLevel>4</WarningLevel>
-    <NoStdLib>False</NoStdLib>
     <NoWarn>CA1416,SYSLIB0011,SYSLIB0014,SYSLIB0039</NoWarn>
-    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <BaseAddress>285212672</BaseAddress>
-    <ConfigurationOverrideFile></ConfigurationOverrideFile>
-    <DefineConstants></DefineConstants>
-    <DocumentationFile></DocumentationFile>
-    <DebugSymbols>False</DebugSymbols>
-    <FileAlignment>4096</FileAlignment>
-    <Optimize>True</Optimize>
-    <TieredCompilationQuickJit>false</TieredCompilationQuickJit>
-    <UseCommonOutputDirectory>True</UseCommonOutputDirectory>
-    <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>False</AppendRuntimeIdentifierToOutputPath>
-    <RegisterForComInterop>False</RegisterForComInterop>
-    <RemoveIntegerChecks>False</RemoveIntegerChecks>
-    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-    <WarningLevel>4</WarningLevel>
-    <NoStdLib>False</NoStdLib>
-    <NoWarn>CA1416,SYSLIB0011,SYSLIB0014,SYSLIB0039</NoWarn>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
-
-  <!-- OpenMetaverse via NuGet (develop migrated libomv off Library/ DLLs). -->
+  <!-- ANTLR3-generated sources and the duplicate grammar/generated/ copies are
+       superseded by the ANTLR4 visitors compiled from Compiler/ and ByteCompiler/. -->
   <ItemGroup>
-	  <PackageReference Include="protobuf-net" Version="3.2.30" />
+    <Compile Remove="grammar\generated\**\*.cs" />
+    <Compile Remove="Compiler\Def.cs" />
+    <Compile Remove="Compiler\Types.cs" />
+    <Compile Remove="Compiler\Analyze.cs" />
+    <Compile Remove="Compiler\Gen.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="protobuf-net" Version="3.2.56" />
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="StringTemplate4" Version="4.0.8" />
   </ItemGroup>
 
-  <!-- C5 via develop's Library/C5.dll (single identity — avoids the dual-C5 TypeLoadException). -->
+  <!-- C5 via develop's Library/C5.dll (single identity - avoids the dual-C5 TypeLoadException). -->
   <ItemGroup>
     <Reference Include="C5" HintPath="..\..\Library\C5.dll" />
   </ItemGroup>
@@ -73,311 +41,6 @@
   <ItemGroup>
     <ProjectReference Include="..\OpenSim.Framework\OpenSim.Framework.csproj" />
     <ProjectReference Include="..\OpenSim.Region.Framework\OpenSim.Region.Framework.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="ByteCompiler\AssemblerLexer.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\AssemblerParser.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\AssemblerVisitor.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\AssemblerBaseVisitor.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\BytecodeGenerator.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\EventSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\FunctionSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\FwdReferenceBehavior.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\GenerationException.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="ByteCompiler\LabelSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\BaseScope.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\Branch.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\BuiltInTypeSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\ConstantSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\DefaultConstants.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\EventSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\GlobalScope.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\IScope.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\ISymbolType.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LabelSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LocalScope.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LSLAst.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LSLBaseVisitor.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LSLErrorNode.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LSLLexer.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LSLParser.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LSLTreeAdaptor.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\LSLVisitor.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\MethodSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\ScopedSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\StateSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\Symbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\SymbolTable.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\TemplateMapping.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Compiler\VariableSymbol.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Glue\CompilerFrontend.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Glue\ISystemAPI.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Glue\LSLListenerTraceRedirector.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Glue\SyscallShim.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Serialization\SerializationException.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Serialization\SerializedLSLList.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Serialization\SerializedLSLPrimitive.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Serialization\SerializedPostedEvent.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Serialization\SerializedRuntimeState.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Serialization\SerializedScript.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Serialization\SerializedStackFrame.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\CheckException.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\DefaultLSLListener.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\Defaults.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\FunctionSig.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\ILSLListener.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\ISyscallShim.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\LSLList.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\NullListener.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\OpCodes.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\ScriptUnloadReason.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\Sentinel.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\SupportedEventList.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\TooManyErrorsException.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Types\VarTypes.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Util\Clock.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Util\Encoding.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Util\LinkedHashMap.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Util\MemoryCalc.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Util\Preloader.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\ActiveListen.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\CompiledScript.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\DetectVariables.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\EventInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\FunctionInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\Interpreter.Actions.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\Interpreter.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\MemoryInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\PostedEvent.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\RuntimeState.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\StackFrame.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="VM\VMException.cs">
-      <SubType>Code</SubType>
-    </Compile>
-	<Compile Include="Compiler\CompilerStubs.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Compiler\LSLListener.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="ByteCompiler\AssemblerListener.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="ByteCompiler\AssemblerBaseListener.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Compiler\LSLBaseListener.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Compiler\DefVisitor.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Compiler\TypesVisitor.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Compiler\AnalyzeVisitor.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Compiler\GenVisitor.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Compiler\ByteCodeEmitter.cs">
-	  <SubType>Code</SubType>
-	</Compile>	
-	<Compile Include="SLua\SLuaCompiler.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="SLua\LuaLib.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="SLua\LuaPattern.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Types\LSLTable.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Types\LuaClosure.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Types\LuaGmatch.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Types\LuaNil.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Types\LuaError.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Types\LuaDetected.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	<Compile Include="Serialization\SerializedLSLTable.cs">
-	  <SubType>Code</SubType>
-	</Compile>
-	  </ItemGroup>
-
-  <!-- Exclude ANTLR3-generated files — replaced by ANTLR4 visitors -->
-  <ItemGroup>
-    <Compile Remove="Compiler\Def.cs" />
-    <Compile Remove="Compiler\Types.cs" />
-    <Compile Remove="Compiler\Analyze.cs" />
-    <Compile Remove="Compiler\Gen.cs" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.ApplicationPlugins.LoadRegions/OpenSim.ApplicationPlugins.LoadRegions.csproj
+++ b/Source/OpenSim.ApplicationPlugins.LoadRegions/OpenSim.ApplicationPlugins.LoadRegions.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.ApplicationPlugins.LoadRegions</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -11,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/OpenSim.ApplicationPlugins.RegionModulesController/OpenSim.ApplicationPlugins.RegionModulesController.csproj
+++ b/Source/OpenSim.ApplicationPlugins.RegionModulesController/OpenSim.ApplicationPlugins.RegionModulesController.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.ApplicationPlugins.RegionModulesController</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -11,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/OpenSim.ApplicationPlugins.RemoteController/OpenSim.ApplicationPlugins.RemoteController.csproj
+++ b/Source/OpenSim.ApplicationPlugins.RemoteController/OpenSim.ApplicationPlugins.RemoteController.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.ApplicationPlugins.RemoteController</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -8,8 +7,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/OpenSim.Capabilities.Handlers/OpenSim.Capabilities.Handlers.csproj
+++ b/Source/OpenSim.Capabilities.Handlers/OpenSim.Capabilities.Handlers.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Capabilities.Handlers</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -23,10 +22,10 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.Capabilities/OpenSim.Capabilities.csproj
+++ b/Source/OpenSim.Capabilities/OpenSim.Capabilities.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Capabilities</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -19,7 +18,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.ConsoleClient/OpenSim.ConsoleClient.csproj
+++ b/Source/OpenSim.ConsoleClient/OpenSim.ConsoleClient.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
@@ -16,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.8" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.CommandLine" Version="2.0.10" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Data.Model/OpenSim.Data.Model.csproj
+++ b/Source/OpenSim.Data.Model/OpenSim.Data.Model.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ProjectType>Local</ProjectType>
     <OutputType>Library</OutputType>
     <PackageId>OpenSim.Data.Model</PackageId>
@@ -14,23 +13,23 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.27" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.14">
+    <PackageReference Include="MediatR" Version="14.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
     <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10" PrivateAssets="all" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/OpenSim.Data.Model/readme.md
+++ b/Source/OpenSim.Data.Model/readme.md
@@ -13,7 +13,7 @@ It is intended to be the shared data-model foundation used by the rest of the NG
 ## Package Summary
 
 - Package ID: `OpenSim.Data.Model`
-- Target framework: `.NET 8` (`net8.0`)
+- Target framework: `.NET 8` (`net10.0`)
 - Database provider: Pomelo MySQL (`Pomelo.EntityFrameworkCore.MySql`)
 - EF Core: `Microsoft.EntityFrameworkCore`
 

--- a/Source/OpenSim.Data.MySQL.MoneyData/OpenSim.Data.MySQL.MoneyData.csproj
+++ b/Source/OpenSim.Data.MySQL.MoneyData/OpenSim.Data.MySQL.MoneyData.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Data.MySQL.MoneyData</AssemblyTitle>
     <Company>OpenSim</Company>
     <Product>OpenSim.Data.MySQL.MoneyData</Product>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="MySqlConnector" Version="2.5.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="MySqlConnector" Version="2.6.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="XMLRPC" HintPath="../../Library/XMLRPC.dll" />

--- a/Source/OpenSim.Data.MySQL/OpenSim.Data.MySQL.csproj
+++ b/Source/OpenSim.Data.MySQL/OpenSim.Data.MySQL.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Data.MySQL</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data.MySQL</Product>
@@ -40,9 +39,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="MySqlConnector" Version="2.5.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="MySqlConnector" Version="2.6.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.Data.Null/OpenSim.Data.Null.csproj
+++ b/Source/OpenSim.Data.Null/OpenSim.Data.Null.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Data.Null</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data.Null</Product>
@@ -21,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Data.PGSQL/OpenSim.Data.PGSQL.csproj
+++ b/Source/OpenSim.Data.PGSQL/OpenSim.Data.PGSQL.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Data.PGSQL</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data.PGSQL</Product>
@@ -38,9 +37,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="Npgsql" Version="10.0.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/OpenSim.Data.SQLite/OpenSim.Data.SQLite.csproj
+++ b/Source/OpenSim.Data.SQLite/OpenSim.Data.SQLite.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Data.SQLite</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data.SQLite</Product>
@@ -35,8 +34,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="System.Data.SQLite" Version="2.0.4" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Data/OpenSim.Data.csproj
+++ b/Source/OpenSim.Data/OpenSim.Data.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Data</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim.Data</Product>
@@ -13,9 +12,9 @@
     <ProjectReference Include="../../Source/OpenSim.Framework/OpenSim.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="MySqlConnector" Version="2.5.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="MySqlConnector" Version="2.6.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="System.Data.SQLite" Version="2.0.4" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Framework.AssetLoader.Filesystem/OpenSim.Framework.AssetLoader.Filesystem.csproj
+++ b/Source/OpenSim.Framework.AssetLoader.Filesystem/OpenSim.Framework.AssetLoader.Filesystem.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Framework.AssetLoader.Filesystem</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -16,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Framework.Console/OpenSim.Framework.Console.csproj
+++ b/Source/OpenSim.Framework.Console/OpenSim.Framework.Console.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Framework.Console</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>ServerConsole</Product>
@@ -11,8 +10,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/OpenSim.Framework.Monitoring/OpenSim.Framework.Monitoring.csproj
+++ b/Source/OpenSim.Framework.Monitoring/OpenSim.Framework.Monitoring.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Framework.Monitoring</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -15,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Framework.Serialization/OpenSim.Framework.Serialization.csproj
+++ b/Source/OpenSim.Framework.Serialization/OpenSim.Framework.Serialization.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Framework.Serialization</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -13,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Framework.Servers.HttpServer/OpenSim.Framework.Servers.HttpServer.csproj
+++ b/Source/OpenSim.Framework.Servers.HttpServer/OpenSim.Framework.Servers.HttpServer.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Framework.Servers.HttpServer</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -17,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.Framework.Servers/OpenSim.Framework.Servers.csproj
+++ b/Source/OpenSim.Framework.Servers/OpenSim.Framework.Servers.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Framework.Servers</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -20,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Framework/OpenSim.Framework.csproj
+++ b/Source/OpenSim.Framework/OpenSim.Framework.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-      <TargetFramework>net8.0</TargetFramework>
       <AssemblyTitle>OpenSim.Framework</AssemblyTitle>
       <Company>http://opensimulator.org</Company>
       <Product>OpenSim.Framework</Product>
@@ -14,14 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="System.Security.Permissions" Version="10.0.8" />
-    <PackageReference Include="System.Threading.AccessControl" Version="10.0.8" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="System.Security.Permissions" Version="10.0.10" />
+    <PackageReference Include="System.Threading.AccessControl" Version="10.0.10" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
-    <PackageReference Include="log4net" Version="3.3.1" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
+    <PackageReference Include="log4net" Version="3.3.2" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
     <PackageReference Include="zlib.net-mutliplatform" Version="1.1.0" />
   </ItemGroup>

--- a/Source/OpenSim.Framework/SkiaImageUtils.cs
+++ b/Source/OpenSim.Framework/SkiaImageUtils.cs
@@ -201,10 +201,11 @@ public static class SkiaImageUtils
         using (SKPaint paint = new())
         {
             paint.IsAntialias = true;
-            paint.FilterQuality = SKFilterQuality.High;
+
+            SKSamplingOptions sampling = new(SKCubicResampler.Mitchell);
 
             canvas.Clear(SKColors.Transparent);
-            canvas.DrawBitmap(image, new SKRect(0, 0, width, height), paint);
+            canvas.DrawBitmap(image, new SKRect(0, 0, width, height), sampling, paint);
         }
 
         return result;

--- a/Source/OpenSim.Framework/Util.cs
+++ b/Source/OpenSim.Framework/Util.cs
@@ -2395,7 +2395,7 @@ public static class Util
 
         memory.Position = 0;
         using GZipStream decompressor = new(memory, CompressionMode.Decompress);
-        decompressor.Read(buffer, 0, buffer.Length);
+        decompressor.ReadExactly(buffer, 0, buffer.Length);
 
         return Util.UTF8.GetString(buffer);
     }
@@ -2701,7 +2701,7 @@ public static class Util
     public static OSDMap GetOSDMap(Stream stream, int length)
     {
         byte[] data = new byte[length];
-        stream.Read(data, 0, length);
+        stream.ReadExactly(data, 0, length);
         string strdata = Util.UTF8.GetString(data);
         OSDMap args;
         OSD buffer;

--- a/Source/OpenSim.Region.ClientStack.LindenCaps/OpenSim.Region.ClientStack.LindenCaps.csproj
+++ b/Source/OpenSim.Region.ClientStack.LindenCaps/OpenSim.Region.ClientStack.LindenCaps.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.ClientStack.LindenCaps</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -24,8 +23,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Region.ClientStack.LindenUDP/OpenSim.Region.ClientStack.LindenUDP.csproj
+++ b/Source/OpenSim.Region.ClientStack.LindenUDP/OpenSim.Region.ClientStack.LindenUDP.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.ClientStack.LindenUDP</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -26,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.CoreModules/OpenSim.Region.CoreModules.csproj
+++ b/Source/OpenSim.Region.CoreModules/OpenSim.Region.CoreModules.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.CoreModules</AssemblyTitle>
     <Product>OpenSim.Region.CoreModules.Properties</Product>
     <Description>Core modules for OpenSim</Description>
@@ -35,12 +34,12 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="MailKit" Version="4.16.0" />
-    <PackageReference Include="MimeKit" Version="4.16.0" />
-    <PackageReference Include="MySqlConnector" Version="2.5.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
+    <PackageReference Include="MimeKit" Version="4.17.0" />
+    <PackageReference Include="MySqlConnector" Version="2.6.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.Framework/OpenSim.Region.Framework.csproj
+++ b/Source/OpenSim.Region.Framework/OpenSim.Region.Framework.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.Framework</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -26,10 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Permissions" Version="10.0.8" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
-    <PackageReference Include="log4net" Version="3.3.1" />
+    <PackageReference Include="System.Security.Permissions" Version="10.0.10" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
+    <PackageReference Include="log4net" Version="3.3.2" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.OptionalModules/OpenSim.Region.OptionalModules.csproj
+++ b/Source/OpenSim.Region.OptionalModules/OpenSim.Region.OptionalModules.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.OptionalModules</AssemblyTitle>
     <Product>OpenSim.Region.OptionalModules.Properties</Product>
     <Description>Optional modules for OpenSim</Description>
@@ -35,10 +34,10 @@
   </ItemGroup>
 
 <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="System.Data.SQLite" Version="2.0.4" />
     <!-- Phlox bot framework: BotPersistenceManager keeps its isolated local bot DB via Microsoft.Data.Sqlite -->
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.PhysicsModules.BasicPhysics/OpenSim.Region.PhysicsModules.BasicPhysics.csproj
+++ b/Source/OpenSim.Region.PhysicsModules.BasicPhysics/OpenSim.Region.PhysicsModules.BasicPhysics.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.PhysicsModules.BasicPhysics</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -17,7 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.PhysicsModules.BulletS/OpenSim.Region.PhysicsModules.BulletS.csproj
+++ b/Source/OpenSim.Region.PhysicsModules.BulletS/OpenSim.Region.PhysicsModules.BulletS.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.PhysicsModules.BulletS</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -28,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet/OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet.csproj
+++ b/Source/OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet/OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.PhysicsModules.ConvexDecompositionDotNet</AssemblyTitle>
     <Company>Intel Corporation</Company>
     <Product>OpenSim</Product>
@@ -8,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/OpenSim.Region.PhysicsModules.Meshing/OpenSim.Region.PhysicsModules.Meshing.csproj
+++ b/Source/OpenSim.Region.PhysicsModules.Meshing/OpenSim.Region.PhysicsModules.Meshing.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.PhysicsModules.Meshing</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -8,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/OpenSim.Region.PhysicsModules.POS/OpenSim.Region.PhysicsModules.POS.csproj
+++ b/Source/OpenSim.Region.PhysicsModules.POS/OpenSim.Region.PhysicsModules.POS.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.PhysicsModules.POS</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -17,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.PhysicsModules.SharedBase/OpenSim.Region.PhysicsModules.SharedBase.csproj
+++ b/Source/OpenSim.Region.PhysicsModules.SharedBase/OpenSim.Region.PhysicsModules.SharedBase.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.PhysicsModules.SharedBase</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -16,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.Region.PhysicsModules.ubODE/OpenSim.Region.PhysicsModules.ubODE.csproj
+++ b/Source/OpenSim.Region.PhysicsModules.ubODE/OpenSim.Region.PhysicsModules.ubODE.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.PhysicsModules.ubODE</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>ubODE</Product>
@@ -28,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.PhysicsModules.ubODEMeshing/OpenSim.Region.PhysicsModules.ubODEMeshing.csproj
+++ b/Source/OpenSim.Region.PhysicsModules.ubODEMeshing/OpenSim.Region.PhysicsModules.ubODEMeshing.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.PhysicsModules.ubODEMeshing</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -21,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Region.ScriptEngine.Shared/OpenSim.Region.ScriptEngine.Shared.csproj
+++ b/Source/OpenSim.Region.ScriptEngine.Shared/OpenSim.Region.ScriptEngine.Shared.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.ScriptEngine.Shared</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -20,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/OpenSim.Region.ScriptEngine.YEngine.csproj
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/OpenSim.Region.ScriptEngine.YEngine.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Region.ScriptEngine.YEngine</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -23,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Region.ScriptEngine.YEngine/XMRObjectTokens.cs
+++ b/Source/OpenSim.Region.ScriptEngine.YEngine/XMRObjectTokens.cs
@@ -2061,8 +2061,8 @@ public class OTDecompile: ObjectTokens
                  // arrayfieldobj = arg$0.glblVars
                  // iartypename = iar<type>
                 OTOpndField arrayfield = (OTOpndField)array;
-                OTOpnd arrayfieldobj = arrayfield.obj;
-                string iartypename = arrayfield.field.Name;
+                OTOpnd arrayfieldobj = arrayfield.Obj;
+                string iartypename = arrayfield.Field.Name;
 
                  // See if they are what they are supposed to be.
                 if((arrayfieldobj is OTOpndField) && iartypename.StartsWith("iar"))
@@ -2071,7 +2071,7 @@ public class OTDecompile: ObjectTokens
                     OTOpndField arrayfieldobjfield = (OTOpndField)arrayfieldobj;
 
                      // See if the parts are what they are supposed to be.
-                    if(IsArg0OrXMRInst(arrayfieldobjfield.obj) && (arrayfieldobjfield.field.Name == "glblVars"))
+                    if(IsArg0OrXMRInst(arrayfieldobjfield.Obj) && (arrayfieldobjfield.Field.Name == "glblVars"))
                     {
                          // Everything matches up, make a global variable instead of an array reference.
                         return new OTOpndGlobal(iartypename, ((OTOpndInt)index).value, byref, decompile.scriptObjCode);
@@ -2859,8 +2859,8 @@ public class OTDecompile: ObjectTokens
      */
     private class OTOpndField: OTOpnd
     {
-        public OTOpnd obj;
-        public FieldInfo field;
+        public OTOpnd Obj { get; private set; }
+        public FieldInfo Field { get; private set; }
 
         public static OTOpnd Make(OTOpnd obj, FieldInfo field)
         {
@@ -2885,8 +2885,8 @@ public class OTDecompile: ObjectTokens
             // some other field, output code to access it
             // sometimes the object comes as by reference (value types), so we might need to deref it first
             OTOpndField it = new OTOpndField();
-            it.obj = obj.GetNonByRefOpnd();
-            it.field = field;
+            it.Obj = obj.GetNonByRefOpnd();
+            it.Field = field;
             return it;
         }
 
@@ -2898,14 +2898,14 @@ public class OTDecompile: ObjectTokens
         {
             get
             {
-                return obj.HasSideEffects;
+                return Obj.HasSideEffects;
             }
         }
 
         public override void CountRefs(bool writing)
         {
             // the field may be getting written to, but the object is being read
-            obj.CountRefs(false);
+            Obj.CountRefs(false);
         }
 
         public override OTOpnd ReplaceOperand(OTOpnd oldopnd, OTOpnd newopnd, ref bool rc)
@@ -2915,7 +2915,7 @@ public class OTDecompile: ObjectTokens
                 rc = true;
                 return newopnd;
             }
-            obj = obj.ReplaceOperand(oldopnd, newopnd, ref rc);
+            Obj = Obj.ReplaceOperand(oldopnd, newopnd, ref rc);
             return this;
         }
 
@@ -2924,7 +2924,7 @@ public class OTDecompile: ObjectTokens
             if(!(other is OTOpndField))
                 return false;
             OTOpndField otherfield = (OTOpndField)other;
-            return (field.Name == otherfield.field.Name) && obj.SameAs(otherfield.obj);
+            return (Field.Name == otherfield.Field.Name) && Obj.SameAs(otherfield.Obj);
         }
 
         public override string PrintableString
@@ -2932,13 +2932,13 @@ public class OTDecompile: ObjectTokens
             get
             {
                 StringBuilder sb = new StringBuilder();
-                if(obj is OTOpndBinOp)
+                if(Obj is OTOpndBinOp)
                     sb.Append('(');
-                sb.Append(obj.PrintableString);
-                if(obj is OTOpndBinOp)
+                sb.Append(Obj.PrintableString);
+                if(Obj is OTOpndBinOp)
                     sb.Append(')');
                 sb.Append('.');
-                sb.Append(field.Name);
+                sb.Append(Field.Name);
                 return sb.ToString();
             }
         }
@@ -3544,9 +3544,9 @@ public class OTDecompile: ObjectTokens
         {
             get
             {
-                if(field.DeclaringType == typeof(ScriptBaseClass))
-                    return field.Name;
-                return field.DeclaringType.Name + "." + field.Name;
+                if(this.field.DeclaringType == typeof(ScriptBaseClass))
+                    return this.field.Name;
+                return this.field.DeclaringType.Name + "." + this.field.Name;
             }
         }
     }
@@ -4384,16 +4384,16 @@ public class OTDecompile: ObjectTokens
                 if((binop.left is OTOpndField) && (binop.opCode.ToString() == "bne.un") && (binop.rite is OTOpndInt))
                 {
                     OTOpndField leftfield = (OTOpndField)binop.left;
-                    if(leftfield.field.Name == _callMode)
+                    if(leftfield.Field.Name == _callMode)
                     {
                         bool ok = false;
-                        if(leftfield.obj is OTOpndArg)
+                        if(leftfield.Obj is OTOpndArg)
                         {
-                            ok = ((OTOpndArg)leftfield.obj).index == 0;
+                            ok = ((OTOpndArg)leftfield.Obj).index == 0;
                         }
-                        if(leftfield.obj is OTOpndLocal)
+                        if(leftfield.Obj is OTOpndLocal)
                         {
-                            ok = ((OTOpndLocal)leftfield.obj).local.name.StartsWith(_xmrinstlocal);
+                            ok = ((OTOpndLocal)leftfield.Obj).local.name.StartsWith(_xmrinstlocal);
                         }
                         if(ok)
                         {
@@ -4425,12 +4425,12 @@ public class OTDecompile: ObjectTokens
                 if((unop.opCode == MyOp.Brfalse) && (unop.value is OTOpndField))
                 {
                     OTOpndField valuefield = (OTOpndField)unop.value;
-                    if(valuefield.field.Name == _doGblInit)
+                    if(valuefield.Field.Name == _doGblInit)
                     {
                         bool ok = false;
-                        if(valuefield.obj is OTOpndLocal)
+                        if(valuefield.Obj is OTOpndLocal)
                         {
-                            ok = ((OTOpndLocal)valuefield.obj).local.name.StartsWith(_xmrinstlocal);
+                            ok = ((OTOpndLocal)valuefield.Obj).local.name.StartsWith(_xmrinstlocal);
                         }
                         if(ok)
                         {
@@ -4966,9 +4966,9 @@ public class OTDecompile: ObjectTokens
                 if((array.array is OTOpndField) && (array.index is OTOpndInt))
                 {
                     OTOpndField arrayfield = (OTOpndField)array.array;
-                    if((arrayfield.obj is OTOpndLocal) &&
-                            ((OTOpndLocal)arrayfield.obj).local.name.StartsWith(_xmrinstlocal) &&
-                            (arrayfield.field.Name == _ehArgs))
+                    if((arrayfield.Obj is OTOpndLocal) &&
+                            ((OTOpndLocal)arrayfield.Obj).local.name.StartsWith(_xmrinstlocal) &&
+                            (arrayfield.Field.Name == _ehArgs))
                     {
                         int index = ((OTOpndInt)array.index).value;
                         decompile.eharglist[index] = ((OTOpndLocal)varwr).local;

--- a/Source/OpenSim.Server.Base/OpenSim.Server.Base.csproj
+++ b/Source/OpenSim.Server.Base/OpenSim.Server.Base.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Server.Base</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -21,13 +20,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageReference Include="System.CommandLine" Version="2.0.8" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="Autofac" Version="9.3.2" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageReference Include="System.CommandLine" Version="2.0.10" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.Server.GridServer/OpenSim.Server.GridServer.csproj
+++ b/Source/OpenSim.Server.GridServer/OpenSim.Server.GridServer.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyTitle>OpenSim.Server.GridServer</AssemblyTitle>
     <Product>OpenSim.Server.GridServer</Product>
@@ -58,19 +57,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.151.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.151.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.8" />
-    <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.10" />
+    <PackageReference Include="Autofac" Version="9.3.2" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/OpenSim.Server.Handlers/OpenSim.Server.Handlers.csproj
+++ b/Source/OpenSim.Server.Handlers/OpenSim.Server.Handlers.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Server.Handlers</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -23,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Server.MoneyServer/OpenSim.Server.MoneyServer.csproj
+++ b/Source/OpenSim.Server.MoneyServer/OpenSim.Server.MoneyServer.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyTitle>OpenSim.Server.MoneyServer</AssemblyTitle>
     <Product>OpenSim.Server.MoneyServer</Product>
@@ -29,15 +28,15 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.8" />
-    <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.10" />
+    <PackageReference Include="Autofac" Version="9.3.2" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/OpenSim.Server.RegionServer/OpenSim.Server.RegionServer.csproj
+++ b/Source/OpenSim.Server.RegionServer/OpenSim.Server.RegionServer.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyTitle>OpenSim</AssemblyTitle>
     <Product>OpenSim.Server.RegionServer</Product>
@@ -81,19 +80,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="4.151.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.151.1" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="10.0.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.8" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.10" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="Autofac" Version="9.3.2" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/OpenSim.Services.AISv3/OpenSim.Services.AISv3.csproj
+++ b/Source/OpenSim.Services.AISv3/OpenSim.Services.AISv3.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Source/OpenSim.Services.AssetService/OpenSim.Services.AssetService.csproj
+++ b/Source/OpenSim.Services.AssetService/OpenSim.Services.AssetService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.AssetService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -22,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.AuthenticationService/OpenSim.Services.AuthenticationService.csproj
+++ b/Source/OpenSim.Services.AuthenticationService/OpenSim.Services.AuthenticationService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.AuthenticationService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -22,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Services.AuthorizationService/OpenSim.Services.AuthorizationService.csproj
+++ b/Source/OpenSim.Services.AuthorizationService/OpenSim.Services.AuthorizationService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.AuthorizationService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -22,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.Services.AvatarService/OpenSim.Services.AvatarService.csproj
+++ b/Source/OpenSim.Services.AvatarService/OpenSim.Services.AvatarService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.AvatarService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -22,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.Base/OpenSim.Services.Base.csproj
+++ b/Source/OpenSim.Services.Base/OpenSim.Services.Base.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.Base</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -17,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.Connectors/OpenSim.Services.Connectors.csproj
+++ b/Source/OpenSim.Services.Connectors/OpenSim.Services.Connectors.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.Connectors</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -25,9 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Services.EstateService/OpenSim.Services.EstateService.csproj
+++ b/Source/OpenSim.Services.EstateService/OpenSim.Services.EstateService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.EstateService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -18,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Services.ExperienceService/OpenSim.Services.ExperienceService.csproj
+++ b/Source/OpenSim.Services.ExperienceService/OpenSim.Services.ExperienceService.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -19,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.FSAssetService/OpenSim.Services.FSAssetService.csproj
+++ b/Source/OpenSim.Services.FSAssetService/OpenSim.Services.FSAssetService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.FSAssetService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -23,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.FreeswitchService/OpenSim.Services.FreeswitchService.csproj
+++ b/Source/OpenSim.Services.FreeswitchService/OpenSim.Services.FreeswitchService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.FreeswitchService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -21,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.Services.Friends/OpenSim.Services.FriendsService.csproj
+++ b/Source/OpenSim.Services.Friends/OpenSim.Services.FriendsService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.FriendsService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -20,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/Source/OpenSim.Services.GridService/OpenSim.Services.GridService.csproj
+++ b/Source/OpenSim.Services.GridService/OpenSim.Services.GridService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.GridService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -22,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.HypergridService/OpenSim.Services.HypergridService.csproj
+++ b/Source/OpenSim.Services.HypergridService/OpenSim.Services.HypergridService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.HypergridService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -27,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.Interfaces/OpenSim.Services.Interfaces.csproj
+++ b/Source/OpenSim.Services.Interfaces/OpenSim.Services.Interfaces.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.Interfaces</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -17,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.InventoryService/OpenSim.Services.InventoryService.csproj
+++ b/Source/OpenSim.Services.InventoryService/OpenSim.Services.InventoryService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.InventoryService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -21,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/OpenSim.Services.LLLoginService/OpenSim.Services.LLLoginService.csproj
+++ b/Source/OpenSim.Services.LLLoginService/OpenSim.Services.LLLoginService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.LLLoginService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -21,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.MapImageService/OpenSim.Services.MapImageService.csproj
+++ b/Source/OpenSim.Services.MapImageService/OpenSim.Services.MapImageService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.MapImageService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -20,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.MuteListService/OpenSim.Services.MuteListService.csproj
+++ b/Source/OpenSim.Services.MuteListService/OpenSim.Services.MuteListService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.MuteListService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -18,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Services.PresenceService/OpenSim.Services.PresenceService.csproj
+++ b/Source/OpenSim.Services.PresenceService/OpenSim.Services.PresenceService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.PresenceService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -21,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Source/OpenSim.Services.SimulationService/OpenSim.Services.SimulationService.csproj
+++ b/Source/OpenSim.Services.SimulationService/OpenSim.Services.SimulationService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.SimulationService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -20,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.UserAccountService/OpenSim.Services.UserAccountService.csproj
+++ b/Source/OpenSim.Services.UserAccountService/OpenSim.Services.UserAccountService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.UserAccountService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -21,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/OpenSim.Services.UserProfilesService/OpenSim.Services.UserProfilesService.csproj
+++ b/Source/OpenSim.Services.UserProfilesService/OpenSim.Services.UserProfilesService.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>OpenSim.Services.UserProfilesService</AssemblyTitle>
     <Company>http://opensimulator.org</Company>
     <Product>OpenSim</Product>
@@ -23,8 +22,8 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.3.1" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="log4net" Version="3.3.2" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
   </ItemGroup>
   
 </Project>

--- a/Source/Phlox.ScriptEngine/Phlox.ScriptEngine.csproj
+++ b/Source/Phlox.ScriptEngine/Phlox.ScriptEngine.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <!-- Matches YEngine: this lib transitively references the OpenSim app project, which
          under solution-level `dotnet publish -r` produces a duplicate apphost relative path
          (NETSDK1152). Suppress, as YEngine does, so publish succeeds. -->
@@ -26,8 +25,8 @@
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="3.*" />
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
-    <PackageReference Include="log4net" Version="3.3.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageReference Include="log4net" Version="3.3.2" />
   </ItemGroup>
 
   <!-- C5 via develop's Library/C5.dll (single identity — avoids the dual-C5 TypeLoadException). -->

--- a/Source/Warp3D/Warp3D.csproj
+++ b/Source/Warp3D/Warp3D.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyTitle>Warp3D</AssemblyTitle>
     <Company>http://utopiaskye.com</Company>
     <SignAssembly>true</SignAssembly>
@@ -8,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
-    <PackageReference Include="CoreJ2K.Skia" Version="2.1.2.38" />
+    <PackageReference Include="SkiaSharp" Version="4.151.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
+    <PackageReference Include="CoreJ2K.Skia" Version="2.3.3.91" />
   </ItemGroup>
 
 </Project>

--- a/Source/Warp3D/warp_Texture.cs
+++ b/Source/Warp3D/warp_Texture.cs
@@ -409,8 +409,9 @@ public class warp_Texture : IDisposable
             canvas.Clear(SKColors.Transparent);
             var srcRect = new SKRect(0, 0, src.Width, src.Height);
             var dstRect = new SKRect(0, 0, width, height);
-            var paint = new SKPaint { FilterQuality = SKFilterQuality.High };
-            canvas.DrawBitmap(src, srcRect, dstRect, paint);
+            var sampling = new SKSamplingOptions(SKCubicResampler.Mitchell);
+            using var paint = new SKPaint { IsAntialias = true };
+            canvas.DrawBitmap(src, srcRect, dstRect, sampling, paint);
         }
         return dst;
     }

--- a/Tests/OpenSim.Capabilities.Handlers.Tests/OpenSim.Capabilities.Handlers.Tests.csproj
+++ b/Tests/OpenSim.Capabilities.Handlers.Tests/OpenSim.Capabilities.Handlers.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Clients.Assets.Tests/OpenSim.Tests.Clients.AssetClient.csproj
+++ b/Tests/OpenSim.Clients.Assets.Tests/OpenSim.Tests.Clients.AssetClient.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Data.Tests/OpenSim.Data.Tests.csproj
+++ b/Tests/OpenSim.Data.Tests/OpenSim.Data.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Framework.PluginMigration.Tests/OpenSim.Framework.PluginMigration.Tests.csproj
+++ b/Tests/OpenSim.Framework.PluginMigration.Tests/OpenSim.Framework.PluginMigration.Tests.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/OpenSim.Framework.Serialization.Tests/OpenSim.Framework.Serialization.Tests.csproj
+++ b/Tests/OpenSim.Framework.Serialization.Tests/OpenSim.Framework.Serialization.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Framework.Servers.Tests/OpenSim.Framework.Servers.Tests.csproj
+++ b/Tests/OpenSim.Framework.Servers.Tests/OpenSim.Framework.Servers.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Framework.Tests/OpenSim.Framework.Tests.csproj
+++ b/Tests/OpenSim.Framework.Tests/OpenSim.Framework.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Performance.Tests/OpenSim.Tests.Performance.csproj
+++ b/Tests/OpenSim.Performance.Tests/OpenSim.Tests.Performance.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Permissions.Tests/OpenSim.Tests.Permissions.csproj
+++ b/Tests/OpenSim.Permissions.Tests/OpenSim.Tests.Permissions.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Region.ClientStack.LindenCaps.Tests/OpenSim.Region.ClientStack.LindenCaps.Tests.csproj
+++ b/Tests/OpenSim.Region.ClientStack.LindenCaps.Tests/OpenSim.Region.ClientStack.LindenCaps.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Region.ClientStack.LindenUDP.Tests/OpenSim.Region.ClientStack.LindenUDP.Tests.csproj
+++ b/Tests/OpenSim.Region.ClientStack.LindenUDP.Tests/OpenSim.Region.ClientStack.LindenUDP.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Region.CoreModules.Tests/OpenSim.Region.CoreModules.Tests.csproj
+++ b/Tests/OpenSim.Region.CoreModules.Tests/OpenSim.Region.CoreModules.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -34,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/OpenSim.Region.Framework.Tests/OpenSim.Region.Framework.Tests.csproj
+++ b/Tests/OpenSim.Region.Framework.Tests/OpenSim.Region.Framework.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsPublishable>false</IsPublishable>

--- a/Tests/OpenSim.Region.PhysicsModules.BulletS.Tests/OpenSim.Region.PhysicsModule.BulletS.Tests.csproj
+++ b/Tests/OpenSim.Region.PhysicsModules.BulletS.Tests/OpenSim.Region.PhysicsModule.BulletS.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Region.ScriptEngine.Tests/OpenSim.Region.ScriptEngine.Tests.csproj
+++ b/Tests/OpenSim.Region.ScriptEngine.Tests/OpenSim.Region.ScriptEngine.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPublishable>false</IsPublishable>

--- a/Tests/OpenSim.Robust.Tests/Robust.Tests.csproj
+++ b/Tests/OpenSim.Robust.Tests/Robust.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Server.Base.Tests/OpenSim.Server.Base.Tests.csproj
+++ b/Tests/OpenSim.Server.Base.Tests/OpenSim.Server.Base.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -20,15 +19,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/OpenSim.Server.Handlers.Tests/OpenSim.Server.Handlers.Tests.csproj
+++ b/Tests/OpenSim.Server.Handlers.Tests/OpenSim.Server.Handlers.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Services.InventoryService.Tests/OpenSim.Services.InventoryService.Tests.csproj
+++ b/Tests/OpenSim.Services.InventoryService.Tests/OpenSim.Services.InventoryService.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Tests/OpenSim.Stress.Tests/OpenSim.Tests.Stress.csproj
+++ b/Tests/OpenSim.Stress.Tests/OpenSim.Tests.Stress.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Tests/OpenSim.Tests.Common/OpenSim.Tests.Common.csproj
+++ b/Tests/OpenSim.Tests.Common/OpenSim.Tests.Common.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsPublishable>false</IsPublishable>
@@ -10,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.8" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="System.Runtime.Caching" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/OpenSim.Tests/OpenSim.Tests.csproj
+++ b/Tests/OpenSim.Tests/OpenSim.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/Tests/SluaProofRunner/SluaProofRunner.csproj
+++ b/Tests/SluaProofRunner/SluaProofRunner.csproj
@@ -6,7 +6,6 @@
        Console tool, not an NUnit suite; not part of the grid runtime. -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <Nullable>disable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <AssemblyName>SluaProofRunner</AssemblyName>

--- a/Tests/Warp3D.Tests/Warp3D.Tests.csproj
+++ b/Tests/Warp3D.Tests/Warp3D.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,5 +11,5 @@ build:
   verbosity: minimal
 test: off
 artifacts:
-- path: build\Debug\net8.0
+- path: build\Debug\net10.0
   name: NGC-Tranquillity

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "latestFeature",
-    "version": "8.0.0"
+    "rollForward": "latestMajor",
+    "version": "10.0.110"
   }
 }


### PR DESCRIPTION
Now that BinaryFormatter is out of the way update the develop workstream to use dotnet10. We should be able to keep current with evolving dotnet versions going forward.