### PR TITLE
Phlox: implement HasScript and guard OnGetScriptRunning by ownership

### DIFF
--- a/Source/Phlox.ScriptEngine/PhloxEngine.cs
+++ b/Source/Phlox.ScriptEngine/PhloxEngine.cs
@@ -378,8 +378,16 @@ namespace Phlox.ScriptEngine
 
         private void OnGetScriptRunning(IClientAPI controllingClient, UUID objectID, UUID itemID)
         {
-            if (m_ExeScheduler == null) return;
-            // TODO: implement ScriptRunningReply when LindenCaps reference is available
+            // OnGetScriptRunning is a broadcast EventManager event — every registered engine
+            // receives it. Reply ONLY for scripts WE own; otherwise, with YEngine + Phlox both
+            // enabled, Phlox would race a SendScriptRunningReply(false) for a YEngine-owned script
+            // it knows nothing about, and the viewer could show a running script as stopped.
+            // HasScript is the ownership check (FindScript != null), mirroring YEngine's
+            // TryGetInstance guard (XMREngine.cs:1579). SendScriptRunningReply is on IClientAPI
+            // (OpenSim.Framework, already referenced) — no LindenCaps reference is needed.
+            bool running;
+            if (!HasScript(itemID, out running)) return;
+            controllingClient.SendScriptRunningReply(objectID, itemID, running);
         }
 
         private void OnChatFromWorld(object sender, OSChatMessage chat)
@@ -815,7 +823,14 @@ namespace Phlox.ScriptEngine
         }
 
         public System.Collections.ArrayList GetScriptErrors(UUID itemID) => new System.Collections.ArrayList();
-        public bool HasScript(UUID itemID, out bool running) { running = false; return false; }
+        public bool HasScript(UUID itemID, out bool running)
+        {
+            running = false;
+            if (m_ExeScheduler == null || m_ExeScheduler.FindScript(itemID) == null)
+                return false;
+            running = m_ExeScheduler.GetScriptRunning(itemID);
+            return true;
+        }
         public void SaveAllState() { }
         public void StartProcessing() { }
         public float GetScriptExecutionTime(List<UUID> itemIDs)


### PR DESCRIPTION
HasScript was a stub returning false; OnGetScriptRunning was a no-op with a
TODO whose premise was wrong ("when LindenCaps reference is available" --
SendScriptRunningReply is on IClientAPI in OpenSim.Framework, always
available). The result is that the viewer's script-tab Running checkbox
never reflects real state for Phlox scripts: the region never sends
ScriptRunningReply, so the viewer leaves the control disabled and the
request spins indefinitely. Confirmed in-world against a running,
touch-responsive Phlox script.

HasScript now reports ownership (scheduler FindScript != null) plus the
running flag.

OnGetScriptRunning is a broadcast EventManager event delivered to every
registered engine, so it must reply only for scripts it owns. Without the
guard, with YEngine and Phlox both enabled, Phlox would race a
SendScriptRunningReply(false) for a YEngine-owned script it knows nothing
about and the viewer could show a running script as stopped. The ownership
check mirrors YEngine's TryGetInstance guard (XMREngine.cs:1576-1587).

GetScriptErrors left as-is -- the Phlox compiler doesn't currently retain
per-item compile errors, so a real implementation needs an error-accumulating
listener and a per-item store. Worth knowing that the green compile box in
the viewer is therefore not meaningful for Phlox scripts today.