### PR TITLE
Phlox: fire the RegionReady signal from StartProcessing

### DIFF
--- a/Source/Phlox.ScriptEngine/PhloxEngine.cs
+++ b/Source/Phlox.ScriptEngine/PhloxEngine.cs
@@ -817,7 +817,21 @@ namespace Phlox.ScriptEngine
         public System.Collections.ArrayList GetScriptErrors(UUID itemID) => new System.Collections.ArrayList();
         public bool HasScript(UUID itemID, out bool running) { running = false; return false; }
         public void SaveAllState() { }
-        public void StartProcessing() { }
+        public void StartProcessing()
+        {
+            // Phlox compiles asynchronously (OnRezScript enqueues; PhloxScriptLoader
+            // compiles on a worker thread), so unlike YEngine the boot batch is NOT
+            // complete at this point. We fire unconditionally anyway: RegionReadyModule
+            // holds LoginLock until this signal arrives, and gating it on an async
+            // drain barrier risks never firing at all, which is the exact defect this
+            // fixes. Logins may open slightly before the last script finishes
+            // compiling. Do not "correct" this to wait for the queue.
+            if (m_Scene == null || m_Scene.EventManager == null)
+                return;
+
+            m_Scene.EventManager.TriggerEmptyScriptCompileQueue(0, string.Empty);
+            m_log.Info("[PhloxEngine]: StartProcessing fired TriggerEmptyScriptCompileQueue(0) — RegionReady LoginLock release signal");
+        }
         public float GetScriptExecutionTime(List<UUID> itemIDs)
         {
             if (m_ExeScheduler == null || itemIDs == null) return 0f;


### PR DESCRIPTION
PhloxEngine.StartProcessing() was an empty no-op, so on a region where Phlox is the only registered IScriptModule the RegionReady LoginLock is never released and logins hang forever (any region with >=1 active script; empty regions self-heal via the Scene.cs Frame-20 fallback).

Scene.StartScripts() calls StartProcessing() on every registered engine (Scene.Inventory.cs), and RegionReadyModule holds LoginLock until an engine fires EventManager.TriggerEmptyScriptCompileQueue. YEngine does this in its StartProcessing (XMREngine.cs); Phlox did not, so the defect is currently masked only because YEngine is also enabled.

Fire TriggerEmptyScriptCompileQueue(0, "") unconditionally. Phlox compiles asynchronously, so unlike YEngine the boot batch is not drained at this point; gating the signal on an async drain barrier risks never firing, which is the defect. Logins may open slightly before the last script finishes compiling -- acceptable and documented in-code.