### PR TITLE
Fix blank dynamic textures and undersized map tiles: single-tile J2K, and size map tiles to the region

### DIFF
--- a/Source/OpenSim.Region.CoreModules/Scripting/VectorRender/VectorRenderModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Scripting/VectorRender/VectorRenderModule.cs
@@ -67,12 +67,20 @@ public class VectorRenderModule : ISharedRegionModule, IDynamicTextureRender
     ///
     /// Pinned explicitly rather than relying on the library default, so an upstream
     /// change to that default cannot silently reintroduce the fault.
+    ///
+    /// Decomposition levels are 5, not the 4 this shipped with. That is alignment
+    /// rather than a proven fix: of 130 single-tile textures measured in this grid's
+    /// asset cache, 126 use 5 levels and every one at 512px or larger does, while no
+    /// large texture known to render uses 4. The viewer clamps requested discard to
+    /// MAX_DISCARD_LEVEL = 5 (indra/llimage/llimage.h:41), so 5 levels keeps every
+    /// discard the viewer may ask for available in the codestream. It costs nothing --
+    /// at 1024x1024 the output is smaller at 5 levels than at 4.
     /// </remarks>
     private static J2KEncoderConfiguration BuildEncoderConfig(int width, int height)
     {
         return new J2KEncoderConfiguration()
             .WithTiles(t => t.SetSize(width, height))
-            .WithWavelet(w => w.UseIrreversible97().WithDecompositionLevels(4))
+            .WithWavelet(w => w.UseIrreversible97().WithDecompositionLevels(5))
             .WithProgression(p => p.WithOrder(ProgressionOrder.LRCP).WithQualityLayers(0.1f, 0.5f, 1.0f));
     }
 

--- a/Source/OpenSim.Region.CoreModules/Scripting/VectorRender/VectorRenderModule.cs
+++ b/Source/OpenSim.Region.CoreModules/Scripting/VectorRender/VectorRenderModule.cs
@@ -52,10 +52,29 @@ public class VectorRenderModule : ISharedRegionModule, IDynamicTextureRender
     private static object thisLock = new object();
     private static SKTypeface m_typeface = null; // SkiaSharp typeface for measurements
 
-    private readonly J2KEncoderConfiguration encoderConfig = new J2KEncoderConfiguration()
-        .WithTiles(t => t.SetSize(256, 256))
-        .WithWavelet(w => w.UseIrreversible97().WithDecompositionLevels(4))
-        .WithProgression(p => p.WithOrder(ProgressionOrder.LRCP).WithQualityLayers(0.1f, 0.5f, 1.0f));
+    /// <summary>
+    /// Build the J2K encoder configuration for an image of the given size.
+    /// </summary>
+    /// <remarks>
+    /// The tile size is pinned to the image dimensions so the codestream is always a
+    /// SINGLE TILE. Second Life viewers cannot render multi-tile JPEG2000: the decoder
+    /// derives geometry from the tile grid and consumes a discard level per grid halving
+    /// (indra/llimagej2coj/llimagej2coj.cpp), so a tiled texture arrives as a blank grey
+    /// prim with no error anywhere in the pipeline. A fixed 256x256 tile size did this to
+    /// every dynamic texture larger than 256 in either dimension, while smaller ones came
+    /// out single-tile by accident and worked - which made it read as an intermittent
+    /// delivery fault rather than an encoding one.
+    ///
+    /// Pinned explicitly rather than relying on the library default, so an upstream
+    /// change to that default cannot silently reintroduce the fault.
+    /// </remarks>
+    private static J2KEncoderConfiguration BuildEncoderConfig(int width, int height)
+    {
+        return new J2KEncoderConfiguration()
+            .WithTiles(t => t.SetSize(width, height))
+            .WithWavelet(w => w.UseIrreversible97().WithDecompositionLevels(4))
+            .WithProgression(p => p.WithOrder(ProgressionOrder.LRCP).WithQualityLayers(0.1f, 0.5f, 1.0f));
+    }
 
     private Scene m_scene;
     private IDynamicTextureManager m_textureManager;
@@ -407,7 +426,7 @@ public class VectorRenderModule : ISharedRegionModule, IDynamicTextureRender
 
             try
             {
-                imageJ2000 = J2kImage.ToBytes(bitmap, encoderConfig);
+                imageJ2000 = J2kImage.ToBytes(bitmap, BuildEncoderConfig(bitmap.Width, bitmap.Height));
             }
             catch (Exception e)
             {

--- a/Source/OpenSim.Region.CoreModules/World/LegacyMap/MapImageModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/LegacyMap/MapImageModule.cs
@@ -69,11 +69,35 @@ public class MapImageModule : IMapImageGenerator, INonSharedRegionModule
     private IMapTileTerrainRenderer terrainRenderer;
     private bool m_Enabled = false;
 
-    private readonly J2KEncoderConfiguration encoderConfig = new J2KEncoderConfiguration()
-        .WithQuality(0.85)
-        .WithTiles(t => t.SetSize(256, 256))
-        .WithWavelet(w => w.UseIrreversible97().WithDecompositionLevels(7))
-        .WithProgression(p => p.WithOrder(ProgressionOrder.RPCL));
+    /// <summary>
+    /// Build the J2K encoder configuration for a map tile of the given size.
+    /// </summary>
+    /// <remarks>
+    /// The tile size is pinned to the image dimensions so the codestream is always a
+    /// SINGLE TILE, for the same reason as VectorRenderModule.BuildEncoderConfig: Second
+    /// Life viewers cannot render multi-tile JPEG2000, and a tiled image arrives as a blank
+    /// square with no error anywhere in the pipeline.
+    ///
+    /// This matters here only once the map tile is larger than 256 in either dimension.
+    /// While CreateMapTile emitted a fixed 256x256 bitmap the tiling was single-tile by
+    /// accident, so correcting the bitmap size WITHOUT also correcting this would have
+    /// replaced an under-sized map with an unrenderable one - the same blank square, a
+    /// different cause.
+    ///
+    /// Decomposition levels are deliberately left at 7 rather than aligned to the 5 used by
+    /// VectorRenderModule. 5 was chosen there from measurements of textures delivered to a
+    /// viewer over the texture pipeline; map tiles reach the viewer by a different path and
+    /// no equivalent measurement has been taken. Changing it here would be an unverified
+    /// change riding along with a verified one.
+    /// </remarks>
+    private static J2KEncoderConfiguration BuildEncoderConfig(int width, int height)
+    {
+        return new J2KEncoderConfiguration()
+            .WithQuality(0.85)
+            .WithTiles(t => t.SetSize(width, height))
+            .WithWavelet(w => w.UseIrreversible97().WithDecompositionLevels(7))
+            .WithProgression(p => p.WithOrder(ProgressionOrder.RPCL));
+    }
 
     #region IMapImageGenerator Members
 
@@ -81,14 +105,20 @@ public class MapImageModule : IMapImageGenerator, INonSharedRegionModule
     {
         try
         {
-            var mapbmp = new SKBitmap(256, 256);
+            // Size the tile to the region's terrain. A fixed 256x256 rendered only the
+            // first 65,536 of the 1,048,576 height samples a 1024x1024 varregion returns -
+            // 6.25% of the terrain - which is why this only ever showed on varregions.
+            int mapWidth = m_scene.Heightmap.Width;
+            int mapHeight = m_scene.Heightmap.Height;
+
+            var mapbmp = new SKBitmap(mapWidth, mapHeight);
             
             // Create terrain renderer based on scene settings
             terrainRenderer = new TexturedMapTileRenderer();
 
             // Get terrain height data and render it directly
             float[] heightData = m_scene.Heightmap.GetFloatsSerialised();
-            using (var surface = SKSurface.Create(new SKImageInfo(256, 256)))
+            using (var surface = SKSurface.Create(new SKImageInfo(mapWidth, mapHeight)))
             using (var canvas = surface.Canvas)
             {
                 // Draw terrain heights
@@ -106,9 +136,14 @@ public class MapImageModule : IMapImageGenerator, INonSharedRegionModule
                 
                 // Render terrain
                 int index = 0;
-                for (int y = 0; y < 256; y++)
+                // Traversal order (y outer, x inner, index++) is preserved exactly as
+                // found rather than "corrected" against GetFloatsSerialised's ordering.
+                // Every region on this grid is square, so the two are indistinguishable
+                // here; on a non-square varregion they would not be. That is a separate
+                // question from the size bug and is deliberately not answered by this patch.
+                for (int y = 0; y < mapHeight; y++)
                 {
-                    for (int x = 0; x < 256; x++)
+                    for (int x = 0; x < mapWidth; x++)
                     {
                         float height = heightData[index++];
                         // Normalize height to 0-255 range
@@ -148,7 +183,7 @@ public class MapImageModule : IMapImageGenerator, INonSharedRegionModule
             {
                 if (skBitmap != null)
                 {
-                    return J2kImage.ToBytes(skBitmap, encoderConfig);
+                    return J2kImage.ToBytes(skBitmap, BuildEncoderConfig(skBitmap.Width, skBitmap.Height));
                 }
             }
         }


### PR DESCRIPTION
Three fixes to the CoreJ2K/SkiaSharp image paths. All produce a **blank or wrong image with no error anywhere in the pipeline** — every server-side check passes.

Found bringing a 17-region 1024m varregion grid up on Tranquillity. Both files carry the original OpenSimulator BSD-3 header.

> **Corrected after opening.** My original description justified the `MapImageModule` tiling change by the same viewer-side J2K decode as #1. That was wrong — the map path never performs a viewer-side J2K decode — and it omitted the most important consequence of the size fix. Section 3 is rewritten below; commits 1 and 2 are unaffected. See the comment thread for the specifics.

## 1. `VectorRenderModule` — dynamic textures over 256px render blank

`encoderConfig` pinned a fixed **256x256 J2K tile size**, so any dynamic texture larger than 256 in either dimension encoded multi-tile.

**Second Life viewers cannot render multi-tile JPEG2000.** The decoder derives geometry from the tile grid and consumes a discard level per grid halving (`indra/llimagej2coj/llimagej2coj.cpp`). The result is a blank grey prim — valid J2K on disk, `TextureEntry` updated and persisted, `ObjectUpdate` scheduled, nothing logged. The image is right; the encoding is wrong.

Textures at or below 256px came out single-tile *by accident* and worked, so it presented as an intermittent delivery fault rather than an encoding one.

Fixed by pinning tile size to the image dimensions — explicitly, rather than dropping `.WithTiles()`, so a change to the library default cannot silently reintroduce it.

| image | tiles before → after | bytes before → after |
|---|---|---|
| 512x512 | 2x2 → 1x1 | 4636 → 3824 |
| 1024x1024 | 4x4 → 1x1 | 9099 → 5926 |

Single-tile is also smaller — tiling added overhead for a format the viewer could not read.

## 2. `VectorRenderModule` — decomposition levels 4 → 5

**Alignment, not a proven fix, and not claimed as the cause of anything.** Of 130 single-tile textures in one grid asset cache, 126 use 5 decomposition levels and every one at 512px or larger does; no large texture known to render uses 4. The viewer clamps requested discard to `MAX_DISCARD_LEVEL = 5` (`indra/llimage/llimage.h:41`), so 5 keeps every discard it may ask for present in the codestream. At 1024x1024 output is *smaller* at 5 levels (5891 B) than at 4 (5926 B).

Separate commit so it can be dropped independently.

## 3. `MapImageModule` — varregion map tiles

**The size bug.** `CreateMapTile` built a fixed `SKBitmap(256, 256)` and looped 256x256 over `GetFloatsSerialised()`. A 1024x1024 varregion returns 1,048,576 samples; the loop reads 65,536 — the first 64 of 1024 terrain rows. Stock OpenSimulator sized the bitmap from the heightmap. Only affects varregions, which is why it shipped.

### ⚠ This fix changes which upload branch runs — please review this specifically

`MapImageServiceModule.UploadMapTile` branches on tile size (`MapImageServiceModule.cs:232`):

```csharp
if (mapTile.Width == Constants.RegionSize && mapTile.Height == Constants.RegionSize)
    ConvertAndUploadMaptile(...);   // legacy: ONE tile
else
    // cut into Constants.RegionSize pieces and upload each
```

`Constants.RegionSize` is 256. **Before this fix `CreateMapTile` returned 256x256, so every varregion took the legacy branch and uploaded exactly one tile** at its base coordinate — leaving the regions other 15 grid cells with no tile at all. That is the actual mechanism behind blank areas on the world map: *missing tiles, not a small one*.

After the fix a 1024m region returns 1024x1024 and takes the varregion branch, uploading 16 sub-tiles. On this codebase that branch appears never to have executed, because nothing else produced a non-legacy-sized tile. It reads as sound — the `top` computation handles the upper-left image origin against lower-left region numbering, and it aborts the whole region rather than uploading a partial set — but reviewers who know its history should weigh in. Watch for `Upload {16} maptiles for ...` and the abort path.

**Operational note for anyone deploying this:** `MaptileRefresh` defaults to 0 (generate at region start only), so this corrects tiles for regions that restart. It does not retract already-uploaded tiles, and map services will keep serving stale composites until they rebuild.

### The tiling change in this file is dead-code hygiene, not a fix

`MapImageModule`s `J2KEncoderConfiguration` is reached only from `WriteJpeg2000Image()`, and I can find **no caller** of that method in the tree — only the two implementations and the `ITerrain` declaration. The map upload path encodes **JPEG 95** (`MapImageServiceModule.cs:289`), so no viewer-side J2K decode occurs on this path and the multi-tile fault of #1 cannot arise here.

I have kept the change so the two encoder configs share one shape and a future caller cannot inherit the fault, but it is **not** load-bearing and I would rather say so than let it borrow #1s evidence. Happy to drop it if you would prefer this file changed only where it executes.

Decomposition levels left at **7**, deliberately — not aligned down to the 5 above. The viewer clamps to `MAX_DISCARD_LEVEL = 5`, so 7 already exceeds anything requestable; aligning would be a reduction, not an alignment.

Loop traversal order is preserved exactly as found. Every region this was diagnosed against is square, so row-major and column-major are indistinguishable here; on a non-square varregion they would not be. A real question, deliberately not answered here.

## Verification status

- Builds clean on this branch: `OpenSim.Region.CoreModules`, SDK 10.0.400, **0 errors**, restored from public nuget only.
- #1 and #2 were diagnosed and measured against a running grid, encoder output compared byte-for-byte through both configurations.
- **#3 is not yet verified in-world**, and now carries a known branch-activation change. Reviewed, not observed rendering.

Happy to split #3 into its own PR, or hold it until in-world confirmation.