### PR TITLE
MapImageModule: guard the contrast stretch against flat terrain

### DIFF
--- a/Source/OpenSim.Region.CoreModules/World/LegacyMap/MapImageModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/LegacyMap/MapImageModule.cs
@@ -133,6 +133,20 @@ public class MapImageModule : IMapImageGenerator, INonSharedRegionModule
                 }
 
                 float heightRange = maxHeight - minHeight;
+
+                // A region with no terrain edits is PERFECTLY FLAT - TerrainChannel's
+                // default is ClearLand(DefaultTerrainHeight), and DefaultTerrainHeight is
+                // 21f (OpenSim.Framework/TerrainData.cs:87). Every point is then
+                // simultaneously the minimum and the maximum, heightRange is 0, and the
+                // contrast stretch below divides 0f by 0f. That is NaN, and converting NaN
+                // to byte yields 0, so a brand new region renders a PURE BLACK map tile
+                // from its first render onward. No exception is thrown anywhere.
+                //
+                // Written as !(x > 0f) rather than x <= 0f ON PURPOSE: the negated form is
+                // also true for NaN, so a heightmap that already contains NaN is caught
+                // here instead of passing the guard and reaching the division anyway.
+                // Do not "simplify" this to <= 0f.
+                bool flatTerrain = !(heightRange > 0f);
                 
                 // Render terrain
                 int index = 0;
@@ -146,8 +160,14 @@ public class MapImageModule : IMapImageGenerator, INonSharedRegionModule
                     for (int x = 0; x < mapWidth; x++)
                     {
                         float height = heightData[index++];
-                        // Normalize height to 0-255 range
-                        byte gray = (byte)(((height - minHeight) / heightRange) * 255);
+                        // Normalize height to 0-255 range. On flat terrain the stretch has
+                        // no answer - every point is both bounds - so legibility decides:
+                        // mid-grey, which shades to RGB(102,102,102) and is distinct both
+                        // from an empty cell's ocean fill RGB(30,70,95) and from the
+                        // RGB(0,0,0) this used to produce.
+                        byte gray = flatTerrain
+                            ? (byte)128
+                            : (byte)(((height - minHeight) / heightRange) * 255);
                         
                         // Apply some lighting to create terrain shading
                         byte shaded = (byte)(gray * 0.8f); // Darken slightly


### PR DESCRIPTION
Follow-on to #201, same file. A region with no terrain edits renders a **pure black map tile from its first render**, and nothing logs an error.

## The defect

`CreateMapTile` normalises height into a greyscale range:

```csharp
float heightRange = maxHeight - minHeight;
...
byte gray = (byte)(((height - minHeight) / heightRange) * 255);
```

A region with no terrain edits is **perfectly flat** — `TerrainChannel` defaults to `ClearLand(DefaultTerrainHeight)`, and `DefaultTerrainHeight` is `21f` (`OpenSim.Framework/TerrainData.cs:87`). Every point is then simultaneously the minimum and the maximum, so `heightRange` is `0`, the division is `0f / 0f`, and converting the resulting `NaN` to `byte` yields `0`. The shading multiply keeps it `0`.

**This is the default state of every region until somebody edits its terrain**, not an edge case.

## Measured, not reasoned

All four cases run rather than argued:

| case | result |
|---|---|
| flat, guarded | `gray = 128` → `RGB(102,102,102)` |
| flat, unguarded | `NaN` → `gray = 0` → `RGB(0,0,0)` |
| absolute-height fallback | `gray = 21` → `RGB(16,16,16)` |
| real relief | guarded output **identical** to unguarded |

Confirmed against a live grid: a flat region's stored map tile is a uniform `RGB(0,0,0)` JPEG, while an empty map cell is uniform `RGB(30,70,95)` ocean fill. The two are indistinguishable at map-thumbnail scale and by file size, which is why this reads as "the map is broken" rather than as one specific defect.

## Two deliberate choices, both in the code comments

**`!(heightRange > 0f)` rather than `heightRange <= 0f`.** The negated form is also true for `NaN`, so a heightmap that already contains `NaN` is caught by the guard instead of passing it and reaching the division regardless. Verified: `!(NaN > 0f)` is `true`, `(NaN <= 0f)` is `false`. Please do not simplify it — the comment says so at the site.

**Mid-grey rather than falling back to absolute height.** Absolute height is the obvious alternative and it fails on the numbers: `21f` maps to `RGB(16,16,16)`, still visually black, which would look exactly like the fix having failed. Mid-grey is a choice rather than a derivation — on flat terrain the contrast stretch has no correct answer, so legibility decides, and `RGB(102,102,102)` is distinct both from black and from the ocean fill.

`TerrainSplat.cs` already guards `heightRange == 0f` in this same assembly, so the Warp3D path is protected and the LegacyMap path was not. That is precedent that a guard belongs here — **not** precedent for the value, since it returns a texture layer index where `0` is a sensible default rather than a brightness.

## Caveat I would rather state than omit

The C# spec leaves unchecked `float`→integral conversion of `NaN` **unspecified**. The `0` above was measured on arm64; other platforms may differ. The guard makes that conversion unreachable, which resolves the ambiguity rather than depending on it.

## Verification

Builds clean on this branch — `OpenSim.Region.CoreModules`, SDK 10.0.400, **0 errors**, restored from public nuget only. Cherry-picked clean onto `develop` at `ae089ab7a7`.

**Not yet verified in-world.** It is a mechanical correction of a measured defect, reviewed but not observed rendering. Flagging that rather than letting it ride on the evidence above.