### PR TITLE
RegionServer: reference the two os-webrtc-janus projects the shipped ini names

### DIFF
--- a/Source/OpenSim.Server.RegionServer/OpenSim.Server.RegionServer.csproj
+++ b/Source/OpenSim.Server.RegionServer/OpenSim.Server.RegionServer.csproj
@@ -77,6 +77,8 @@
          no manual DLL copying, no compile/runtime identity splits. -->
     <ProjectReference Include="../../Source/Phlox.ScriptEngine/Phlox.ScriptEngine.csproj" />
     <ProjectReference Include="../../Addons/os-webrtc-janus/WebRtcVoiceRegionModule/WebRtcVoiceRegionModule.csproj" />
+    <ProjectReference Include="../../Addons/os-webrtc-janus/WebRtcVoiceServiceModule/WebRtcVoiceServiceModule.csproj" />
+    <ProjectReference Include="../../Addons/os-webrtc-janus/Janus/WebRtcJanusService.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Two lines. The shipped default voice config names assemblies the build does not produce, so WebRTC voice cannot start in any configuration.

## The argument is self-contained

`Addons/os-webrtc-janus/os-webrtc-janus.ini` is tracked, and has exactly two uncommented service lines:

```ini
SpatialVoiceService    = WebRtcJanusService.dll:WebRtcJanusService
NonSpatialVoiceService = WebRtcJanusService.dll:WebRtcJanusService
```

Those two keys are read in **one place in the whole tree** — `WebRtcVoiceServiceModule.cs:79-80`, via `moduleConfig.GetString`. Nothing else reads either key.

So the shipped configuration transitively requires exactly two assemblies: the module that reads the keys, and the assembly its values name. `RegionServer.csproj` references only `WebRtcVoiceRegionModule`, so neither is produced.

That also explains why the pair is two and not four — `WebRtcVoice.dll` already arrives transitively, and `WebRtcVoiceRegionModule.dll` is already referenced.

## Why this looks like a restructure regression rather than an addon problem

Stock OpenSimulator has **one shared `bin/`** that both roles run from, so dropping all four DLLs there was sufficient and no per-role reference existed or was needed — the addon's own README describes it that way. Splitting into separate `GridServer` and `RegionServer` publish trees silently converted *"present in bin"* into *"must be named by each publish tree"*, with no error at any point.

The projects are not abandoned either — `Docs/PLUGIN_MIGRATION_PLAN.md` records porting `WebRtcVoiceServiceModule`'s registration to `IPluginRegistryProvider`. The registration of a module that is not packaged was migrated.

## Verified by content, on this branch

```
before   WebRtcVoice.dll, WebRtcVoiceRegionModule.dll                  2 of 4
after    + WebRtcVoiceServiceModule.dll, WebRtcJanusService.dll        4 of 4
```

`dotnet publish -c Release -r linux-x64`, SDK 10.0.400, restored from public nuget only, 0 errors. Checked by listing the assemblies in the publish tree, not by reading the csproj back.

## Scope

**RegionServer only, deliberately.** `GridServer.csproj` also references none of these. Whether it should depends on whether grid-hosted voice is an intended topology, which is a claim about your design rather than about the shipped config — a separate question that should not hold up this one.

Not verified in-world: standing up Janus is a separate exercise. This fixes the build graph so the assemblies the default config names are actually present.