### PR TITLE
MapImageModule: render through IMapTileTerrainRenderer, as stock does

### DIFF
--- a/Source/OpenSim.Region.CoreModules/World/LegacyMap/MapImageModule.cs
+++ b/Source/OpenSim.Region.CoreModules/World/LegacyMap/MapImageModule.cs
@@ -105,59 +105,32 @@ public class MapImageModule : IMapImageGenerator, INonSharedRegionModule
     {
         try
         {
-            // Size the tile to the region's terrain. A fixed 256x256 rendered only the
-            // first 65,536 of the 1,048,576 height samples a 1024x1024 varregion returns -
-            // 6.25% of the terrain - which is why this only ever showed on varregions.
             int mapWidth = m_scene.Heightmap.Width;
             int mapHeight = m_scene.Heightmap.Height;
 
             var mapbmp = new SKBitmap(mapWidth, mapHeight);
-            
-            // Create terrain renderer based on scene settings
-            terrainRenderer = new TexturedMapTileRenderer();
 
-            // Get terrain height data and render it directly
-            float[] heightData = m_scene.Heightmap.GetFloatsSerialised();
-            using (var surface = SKSurface.Create(new SKImageInfo(mapWidth, mapHeight)))
-            using (var canvas = surface.Canvas)
-            {
-                // Draw terrain heights
-                float maxHeight = float.MinValue;
-                float minHeight = float.MaxValue;
-                
-                // Find height range
-                foreach (var height in heightData)
-                {
-                    maxHeight = Math.Max(maxHeight, height);
-                    minHeight = Math.Min(minHeight, height);
-                }
+            // Render through IMapTileTerrainRenderer, as stock OpenSimulator does.
+            //
+            // This method previously assigned `terrainRenderer = new TexturedMapTileRenderer()`
+            // and then never used the field - written once, read nowhere - producing the tile
+            // from a hand-rolled greyscale loop over GetFloatsSerialised() instead.
+            // TextureOnMapTile was not read at all, so setting it had no effect and the world
+            // map was grey relief regardless of configuration.
+            //
+            // Both renderers are present and already ported to SKBitmap, with
+            // IMapTileTerrainRenderer intact. They were orphaned by the SkiaSharp rewrite,
+            // not removed.
+            string[] configSections = new string[] { "Map", "Startup" };
+            bool textureTerrain = Util.GetConfigVarFromSections<bool>(
+                    m_config, "TextureOnMapTile", configSections, false);
 
-                float heightRange = maxHeight - minHeight;
-                
-                // Render terrain
-                int index = 0;
-                // Traversal order (y outer, x inner, index++) is preserved exactly as
-                // found rather than "corrected" against GetFloatsSerialised's ordering.
-                // Every region on this grid is square, so the two are indistinguishable
-                // here; on a non-square varregion they would not be. That is a separate
-                // question from the size bug and is deliberately not answered by this patch.
-                for (int y = 0; y < mapHeight; y++)
-                {
-                    for (int x = 0; x < mapWidth; x++)
-                    {
-                        float height = heightData[index++];
-                        // Normalize height to 0-255 range
-                        byte gray = (byte)(((height - minHeight) / heightRange) * 255);
-                        
-                        // Apply some lighting to create terrain shading
-                        byte shaded = (byte)(gray * 0.8f); // Darken slightly
-                        var color = new SKColor(shaded, shaded, shaded);
-                        
-                        // Set pixel directly
-                        mapbmp.SetPixel(x, y, color);
-                    }
-                }
-            }
+            terrainRenderer = textureTerrain
+                    ? new TexturedMapTileRenderer()
+                    : (IMapTileTerrainRenderer)new ShadedMapTileRenderer();
+
+            terrainRenderer.Initialise(m_scene, m_config);
+            terrainRenderer.TerrainToBitmap(mapbmp);
 
             if (m_scene?.Entities != null && m_scene.Entities.Count > 0)
             {


### PR DESCRIPTION
The world map renders grey relief regardless of configuration, and `TextureOnMapTile` has no effect. **Verified in-world on a 16-region varregion grid before submitting** — details below.

## The defect

`CreateMapTile` assigns the renderer and then never uses it:

```csharp
// Create terrain renderer based on scene settings
terrainRenderer = new TexturedMapTileRenderer();
```

That field is **written once and read nowhere** in the file. The tile is produced by a hand-rolled greyscale loop over `GetFloatsSerialised()` instead, and `TextureOnMapTile` is not read at all — so the setting is inert and the map is grey relief whatever the configuration says.

Neither `Initialise()` nor `TerrainToBitmap()` is ever called.

**Both renderers are present in the tree**, already ported to `SKBitmap`, with `IMapTileTerrainRenderer` intact and correct signatures. They were orphaned by the SkiaSharp rewrite — not removed, not left unfinished. Nothing calls them.

## The fix

Restores the stock path: read `TextureOnMapTile` from `[Map]`/`[Startup]`, select textured or shaded, `Initialise`, `TerrainToBitmap`. 21 insertions, 48 deletions — it removes more than it adds, because the replacement is the code that already exists.

## Verified in-world, not only reasoned about

Deployed to two regions, then to all sixteen, on a 1024m varregion grid:

| | before | after |
|---|---|---|
| sub-tiles uploaded per region | 1 | **16** |
| tile size | 1144 B | **5.7–7.6 KB** |
| distinct colours in a tile | 1 | **6098** |
| greyscale pixels | 100% (structural) | **0.5%** |

The old loop emitted `SKColor(shaded, shaded, shaded)` for every pixel, so 100% greyscale was by construction; 0.5% is incidental JPEG overlap on colour data. Dominant colours after the fix are water, sand and green.

The full landmass now resolves as coloured terrain at every zoom level, where previously it was grey and black squares.

## Note on the sub-tile count

The jump from 1 to 16 uploads is a second-order effect of the region-size fix in #201, surfaced by this change. `MapImageServiceModule` uploads a single tile when the map is exactly `Constants.RegionSize` and splits into sub-tiles otherwise. Before #201, every varregion returned 256x256 and took the single-tile path, leaving the region's other cells without imagery. That branch had never executed on our grid.

## Relationship to #202

**This supersedes my own PR #202** and I am closing that one. #202 added a NaN guard to the contrast stretch in this method, for the case where a perfectly flat region gives `heightRange == 0` and `(byte)(0f/0f)` yields a pure black tile. That guard was correct for the hand-rolled loop — but this change removes the loop entirely, so the division it guarded no longer exists here.

The flat-region case is still handled: `ShadedMapTileRenderer` works from absolute height with its own NaN handling, and `TexturedMapTileRenderer` samples terrain textures. Neither divides by a height range. Confirmed on a flat region, which rendered pure black before and renders uniform terrain colour after.

Builds clean: `OpenSim.Region.CoreModules`, SDK 10.0.400, 0 errors, restored from public nuget only.